### PR TITLE
Add GitHub API key preferences with secure Keychain storage

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -2,22 +2,57 @@ import SwiftUI
 
 @main
 struct MenuBarApp: App {
+    @StateObject private var appSettings = AppSettings.shared
+    
     var body: some Scene {
-        MenuBarExtra("Hello world", systemImage: "star.fill") {
+        MenuBarExtra("GitHub PRs", systemImage: "arrow.triangle.pull") {
             MenuBarExtraView()
         }
+        .menuBarExtraStyle(.window)
     }
 }
 
 struct MenuBarExtraView: View {
+    @StateObject private var appSettings = AppSettings.shared
+    
     var body: some View {
-        VStack {
+        VStack(alignment: .leading, spacing: 8) {
+            if appSettings.hasAPIKey {
+                Text("GitHub PRs")
+                    .font(.headline)
+                    .padding(.bottom, 4)
+                
+                Divider()
+                
+                Text("Pull requests will appear here")
+                    .foregroundColor(.secondary)
+                    .padding(.vertical, 20)
+                    .frame(maxWidth: .infinity)
+            } else {
+                Label("No API Key Configured", systemImage: "exclamationmark.triangle")
+                    .foregroundColor(.orange)
+                    .padding(.vertical, 8)
+                
+                Text("Please configure your GitHub API key in Preferences")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            
+            Divider()
+            
+            Button("Preferences...") {
+                appSettings.openSettings()
+            }
+            .keyboardShortcut(",", modifiers: .command)
+            
             Button("Quit") {
                 NSApplication.shared.terminate(nil)
             }
             .keyboardShortcut("q")
         }
-        .frame(width: 200)
-        .padding()
+        .frame(width: 280)
+        .padding(.vertical, 8)
     }
 }

--- a/Sources/MenuBarApp/AppSettings.swift
+++ b/Sources/MenuBarApp/AppSettings.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import AppKit
+
+class WindowDelegate: NSObject, NSWindowDelegate {
+    static let shared = WindowDelegate()
+    
+    func windowWillClose(_ notification: Notification) {
+        // Return to accessory app mode when window closes
+        NSApp.setActivationPolicy(.accessory)
+    }
+}
+
+class AppSettings: ObservableObject {
+    static let shared = AppSettings()
+    
+    @Published var hasAPIKey: Bool = false
+    @Published var isSettingsPresented: Bool = false
+    
+    private let keychainManager = KeychainManager.shared
+    private var settingsWindow: NSWindow?
+    
+    private init() {
+        checkForExistingAPIKey()
+    }
+    
+    func checkForExistingAPIKey() {
+        hasAPIKey = keychainManager.getAPIKey() != nil
+    }
+    
+    func saveAPIKey(_ apiKey: String) -> Bool {
+        let success = keychainManager.saveAPIKey(apiKey)
+        if success {
+            hasAPIKey = true
+        }
+        return success
+    }
+    
+    func getAPIKey() -> String? {
+        return keychainManager.getAPIKey()
+    }
+    
+    func deleteAPIKey() -> Bool {
+        let success = keychainManager.deleteAPIKey()
+        if success {
+            hasAPIKey = false
+        }
+        return success
+    }
+    
+    func openSettings() {
+        // For LSUIElement apps, we need to temporarily change activation policy
+        NSApp.setActivationPolicy(.regular)
+        
+        if settingsWindow == nil {
+            let settingsView = SettingsView()
+            let hostingController = NSHostingController(rootView: settingsView)
+            
+            settingsWindow = NSWindow(contentViewController: hostingController)
+            settingsWindow?.title = "Preferences"
+            settingsWindow?.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+            settingsWindow?.isReleasedWhenClosed = false
+            settingsWindow?.center()
+            settingsWindow?.setFrameAutosaveName("PreferencesWindow")
+            
+            // Set delegate to handle window closing
+            settingsWindow?.delegate = WindowDelegate.shared
+        }
+        
+        NSApp.activate(ignoringOtherApps: true)
+        settingsWindow?.makeKeyAndOrderFront(nil)
+        settingsWindow?.makeFirstResponder(settingsWindow?.contentView)
+    }
+}

--- a/Sources/MenuBarApp/KeychainManager.swift
+++ b/Sources/MenuBarApp/KeychainManager.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+class KeychainManager {
+    static let shared = KeychainManager()
+    
+    private let service = "com.menubarapp.github"
+    private let account = "github-api-key"
+    
+    private init() {}
+    
+    func saveAPIKey(_ apiKey: String) -> Bool {
+        guard let data = apiKey.data(using: .utf8) else { return false }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        
+        SecItemDelete(query as CFDictionary)
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+    
+    func getAPIKey() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let apiKey = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        
+        return apiKey
+    }
+    
+    func deleteAPIKey() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @StateObject private var appSettings = AppSettings.shared
+    @State private var apiKey: String = ""
+    @State private var showAPIKey: Bool = false
+    @State private var showSaveAlert: Bool = false
+    @State private var saveSuccess: Bool = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("GitHub API Settings")
+                .font(.title2)
+                .bold()
+            
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Personal Access Token")
+                    .font(.headline)
+                
+                HStack {
+                    if showAPIKey {
+                        TextField("Enter your GitHub personal access token", text: $apiKey)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        SecureField("Enter your GitHub personal access token", text: $apiKey)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    
+                    Button(action: { showAPIKey.toggle() }) {
+                        Image(systemName: showAPIKey ? "eye.slash" : "eye")
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                
+                Text("You can create a personal access token at github.com/settings/tokens")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            HStack {
+                Button("Save") {
+                    saveAPIKey()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(apiKey.isEmpty)
+                
+                if appSettings.hasAPIKey {
+                    Button("Remove Saved Token") {
+                        removeAPIKey()
+                    }
+                    .foregroundColor(.red)
+                }
+                
+                Spacer()
+            }
+            
+            if appSettings.hasAPIKey && apiKey.isEmpty {
+                Label("API key is already saved in Keychain", systemImage: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                    .font(.caption)
+            }
+        }
+        .padding(20)
+        .frame(width: 450)
+        .alert(isPresented: $showSaveAlert) {
+            Alert(
+                title: Text(saveSuccess ? "Success" : "Error"),
+                message: Text(saveSuccess ? "API key saved successfully" : "Failed to save API key"),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+        .onAppear {
+            loadExistingAPIKey()
+        }
+    }
+    
+    private func loadExistingAPIKey() {
+        if let existingKey = appSettings.getAPIKey() {
+            apiKey = existingKey
+        }
+    }
+    
+    private func saveAPIKey() {
+        let success = appSettings.saveAPIKey(apiKey)
+        saveSuccess = success
+        showSaveAlert = true
+        
+        if success {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                NSApp.keyWindow?.close()
+            }
+        }
+    }
+    
+    private func removeAPIKey() {
+        _ = appSettings.deleteAPIKey()
+        apiKey = ""
+    }
+}


### PR DESCRIPTION
## Summary
- Add preferences window for entering GitHub personal access token
- Implement secure storage using macOS Keychain Services
- Update menu bar UI to show configuration status

## Test plan
- [x] Build and run the app
- [x] Click Preferences menu item or press ⌘,
- [x] Enter a GitHub personal access token
- [x] Verify token is saved securely to Keychain
- [x] Verify menu bar updates to show API key is configured
- [x] Test removing saved token functionality
- [x] Verify window focus works correctly for text entry

🤖 Generated with [Claude Code](https://claude.ai/code)