### PR TITLE
Add GitHub token validation feature

### DIFF
--- a/Sources/MenuBarApp/GitHubAPIService.swift
+++ b/Sources/MenuBarApp/GitHubAPIService.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+struct GitHubRepository: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let fullName: String
+    let `private`: Bool
+    let owner: GitHubOwner
+    
+    enum CodingKeys: String, CodingKey {
+        case id, name, `private`, owner
+        case fullName = "full_name"
+    }
+}
+
+struct GitHubOwner: Codable {
+    let login: String
+    let type: String
+}
+
+struct GitHubUser: Codable {
+    let login: String
+    let id: Int
+    let type: String
+}
+
+struct GitHubOrganization: Codable, Identifiable {
+    let id: Int
+    let login: String
+    let description: String?
+}
+
+struct GitHubValidationResult {
+    let isValid: Bool
+    let user: GitHubUser?
+    let repositories: [GitHubRepository]
+    let organizations: [GitHubOrganization]
+    let error: String?
+    
+    var accessibleReposCount: Int {
+        repositories.count
+    }
+    
+    var displayedRepositories: [GitHubRepository] {
+        Array(repositories.prefix(5))
+    }
+    
+    var remainingReposCount: Int {
+        max(0, repositories.count - 5)
+    }
+}
+
+class GitHubAPIService: ObservableObject {
+    static let shared = GitHubAPIService()
+    
+    @Published var validationResult: GitHubValidationResult?
+    @Published var isValidating: Bool = false
+    
+    private let baseURL = "https://api.github.com"
+    
+    private init() {}
+    
+    func validateToken(_ token: String) async {
+        await MainActor.run {
+            isValidating = true
+            validationResult = nil
+        }
+        
+        do {
+            // Validate token by getting user info
+            let user = try await fetchUser(token: token)
+            
+            // Fetch repositories (limited to first 100 for performance)
+            let repositories = try await fetchRepositories(token: token)
+            
+            // Fetch organizations
+            let organizations = try await fetchOrganizations(token: token)
+            
+            let result = GitHubValidationResult(
+                isValid: true,
+                user: user,
+                repositories: repositories,
+                organizations: organizations,
+                error: nil
+            )
+            
+            await MainActor.run {
+                self.validationResult = result
+                self.isValidating = false
+            }
+            
+        } catch {
+            let result = GitHubValidationResult(
+                isValid: false,
+                user: nil,
+                repositories: [],
+                organizations: [],
+                error: error.localizedDescription
+            )
+            
+            await MainActor.run {
+                self.validationResult = result
+                self.isValidating = false
+            }
+        }
+    }
+    
+    private func fetchUser(token: String) async throws -> GitHubUser {
+        guard let url = URL(string: "\(baseURL)/user") else {
+            throw GitHubAPIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubAPIError.invalidResponse
+        }
+        
+        if httpResponse.statusCode == 401 {
+            throw GitHubAPIError.unauthorized
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            throw GitHubAPIError.httpError(httpResponse.statusCode)
+        }
+        
+        return try JSONDecoder().decode(GitHubUser.self, from: data)
+    }
+    
+    private func fetchRepositories(token: String) async throws -> [GitHubRepository] {
+        guard let url = URL(string: "\(baseURL)/user/repos?per_page=100&sort=updated") else {
+            throw GitHubAPIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw GitHubAPIError.fetchFailed
+        }
+        
+        return try JSONDecoder().decode([GitHubRepository].self, from: data)
+    }
+    
+    private func fetchOrganizations(token: String) async throws -> [GitHubOrganization] {
+        guard let url = URL(string: "\(baseURL)/user/orgs") else {
+            throw GitHubAPIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw GitHubAPIError.fetchFailed
+        }
+        
+        return try JSONDecoder().decode([GitHubOrganization].self, from: data)
+    }
+    
+    func clearValidation() {
+        validationResult = nil
+    }
+}
+
+enum GitHubAPIError: Error, LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case unauthorized
+    case httpError(Int)
+    case fetchFailed
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid GitHub API URL"
+        case .invalidResponse:
+            return "Invalid response from GitHub API"
+        case .unauthorized:
+            return "Invalid or expired GitHub token"
+        case .httpError(let code):
+            return "HTTP error: \(code)"
+        case .fetchFailed:
+            return "Failed to fetch data from GitHub API"
+        }
+    }
+}

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -100,7 +100,9 @@ struct SettingsView: View {
         
         if success {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                NSApp.keyWindow?.close()
+                if let window = NSApp.keyWindow {
+                    window.close()
+                }
             }
         }
     }
@@ -247,5 +249,4 @@ struct TokenValidationResultView: View {
         .background(Color.red.opacity(0.1))
         .cornerRadius(8)
     }
-}
 }

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject private var appSettings = AppSettings.shared
+    @StateObject private var githubService = GitHubAPIService.shared
     @State private var apiKey: String = ""
     @State private var showAPIKey: Bool = false
     @State private var showSaveAlert: Bool = false
@@ -45,6 +46,13 @@ struct SettingsView: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(apiKey.isEmpty)
                 
+                Button("Test Token") {
+                    Task {
+                        await githubService.validateToken(apiKey)
+                    }
+                }
+                .disabled(apiKey.isEmpty || githubService.isValidating)
+                
                 if appSettings.hasAPIKey {
                     Button("Remove Saved Token") {
                         removeAPIKey()
@@ -60,9 +68,12 @@ struct SettingsView: View {
                     .foregroundColor(.green)
                     .font(.caption)
             }
+            
+            // Token validation results
+            TokenValidationResultView()
         }
         .padding(20)
-        .frame(width: 450)
+        .frame(width: 500)
         .alert(isPresented: $showSaveAlert) {
             Alert(
                 title: Text(saveSuccess ? "Success" : "Error"),
@@ -72,6 +83,7 @@ struct SettingsView: View {
         }
         .onAppear {
             loadExistingAPIKey()
+            validateExistingToken()
         }
     }
     
@@ -96,5 +108,144 @@ struct SettingsView: View {
     private func removeAPIKey() {
         _ = appSettings.deleteAPIKey()
         apiKey = ""
+        githubService.clearValidation()
     }
+    
+    private func validateExistingToken() {
+        if let existingKey = appSettings.getAPIKey() {
+            Task {
+                await githubService.validateToken(existingKey)
+            }
+        }
+    }
+}
+
+struct TokenValidationResultView: View {
+    @StateObject private var githubService = GitHubAPIService.shared
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if githubService.isValidating {
+                HStack {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Text("Testing GitHub connection...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            } else if let result = githubService.validationResult {
+                if result.isValid {
+                    validTokenView(result: result)
+                } else {
+                    invalidTokenView(result: result)
+                }
+            }
+        }
+    }
+    
+    private func validTokenView(result: GitHubValidationResult) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Connection successful", systemImage: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.subheadline)
+                .bold()
+            
+            if let user = result.user {
+                Text("Authenticated as: \(user.login)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Divider()
+            
+            // Repositories section
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Accessible Repositories:")
+                    .font(.caption)
+                    .bold()
+                    .foregroundColor(.primary)
+                
+                if result.repositories.isEmpty {
+                    Text("No repositories accessible")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .italic()
+                } else {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(result.displayedRepositories) { repo in
+                            HStack {
+                                Image(systemName: repo.private ? "lock.fill" : "globe")
+                                    .font(.caption2)
+                                    .foregroundColor(repo.private ? .orange : .blue)
+                                Text(repo.fullName)
+                                    .font(.caption)
+                                    .foregroundColor(.primary)
+                                Spacer()
+                            }
+                        }
+                        
+                        if result.remainingReposCount > 0 {
+                            Text("and \(result.remainingReposCount) more...")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .italic()
+                        }
+                    }
+                }
+            }
+            
+            Divider()
+            
+            // Organizations section
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Organizations:")
+                    .font(.caption)
+                    .bold()
+                    .foregroundColor(.primary)
+                
+                if result.organizations.isEmpty {
+                    Text("No organizations accessible")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .italic()
+                } else {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(result.organizations) { org in
+                            HStack {
+                                Image(systemName: "building.2")
+                                    .font(.caption2)
+                                    .foregroundColor(.purple)
+                                Text(org.login)
+                                    .font(.caption)
+                                    .foregroundColor(.primary)
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color.green.opacity(0.1))
+        .cornerRadius(8)
+    }
+    
+    private func invalidTokenView(result: GitHubValidationResult) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Connection failed", systemImage: "xmark.circle.fill")
+                .foregroundColor(.red)
+                .font(.subheadline)
+                .bold()
+            
+            if let error = result.error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        }
+        .padding()
+        .background(Color.red.opacity(0.1))
+        .cornerRadius(8)
+    }
+}
 }


### PR DESCRIPTION
This PR implements the GitHub token validation feature requested in issue #4.

## Changes

- Added GitHubAPIService for token validation and API testing
- Implemented repository and organization listing
- Added visual feedback for connection status
- Display up to 5 repositories with remaining count
- Show accessible organizations
- Added Test Token button to preferences
- Auto-validate existing tokens on preferences load

## Features

- Real-time token validation with GitHub API
- Repository access verification with public/private indicators
- Organization membership display
- Proper error handling for invalid tokens
- Clean UI integration with existing preferences

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)