### PR TITLE
Rename Preferences to Settings

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -33,7 +33,7 @@ struct MenuBarExtraView: View {
                     .foregroundColor(.orange)
                     .padding(.vertical, 8)
                 
-                Text("Please configure your GitHub API key in Preferences")
+                Text("Please configure your GitHub API key in Settings")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -42,7 +42,7 @@ struct MenuBarExtraView: View {
             
             Divider()
             
-            Button("Preferences...") {
+            Button("Settings...") {
                 appSettings.openSettings()
             }
             .keyboardShortcut(",", modifiers: .command)

--- a/Sources/MenuBarApp/AppSettings.swift
+++ b/Sources/MenuBarApp/AppSettings.swift
@@ -56,11 +56,11 @@ class AppSettings: ObservableObject {
             let hostingController = NSHostingController(rootView: settingsView)
             
             settingsWindow = NSWindow(contentViewController: hostingController)
-            settingsWindow?.title = "Preferences"
+            settingsWindow?.title = "Settings"
             settingsWindow?.styleMask = [.titled, .closable, .miniaturizable, .resizable]
             settingsWindow?.isReleasedWhenClosed = false
             settingsWindow?.center()
-            settingsWindow?.setFrameAutosaveName("PreferencesWindow")
+            settingsWindow?.setFrameAutosaveName("SettingsWindow")
             
             // Set delegate to handle window closing
             settingsWindow?.delegate = WindowDelegate.shared


### PR DESCRIPTION
## Summary
- Renamed all occurrences of "Preferences" to "Settings" to align with modern macOS terminology
- Updated menu item, window title, help text, and window autosave name

## Changes
- Menu item: "Preferences..." → "Settings..."
- Window title: "Preferences" → "Settings"
- Help text: "Please configure your GitHub API key in Preferences" → "Please configure your GitHub API key in Settings"
- Window autosave name: "PreferencesWindow" → "SettingsWindow"

## Test plan
- [ ] Verify the menu item shows "Settings..." instead of "Preferences..."
- [ ] Confirm the settings window title displays "Settings"
- [ ] Check that the help text when no API key is configured shows "Settings"
- [ ] Ensure window position is saved/restored properly with the new autosave name

🤖 Generated with [Claude Code](https://claude.ai/code)