### PR TITLE
Show open PRs in menu bar

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+// MARK: - UI Configuration Constants
+private enum UIConstants {
+    static let menuBarWidth: CGFloat = 320
+    static let scrollViewMaxHeight: CGFloat = 400
+}
+
 @main
 struct MenuBarApp: App {
     @StateObject private var appSettings = AppSettings.shared
@@ -59,7 +65,7 @@ struct MenuBarExtraView: View {
                             }
                         }
                     }
-                    .frame(maxHeight: 400)
+                    .frame(maxHeight: UIConstants.scrollViewMaxHeight)
                 }
             } else {
                 Label("No API Key Configured", systemImage: "exclamationmark.triangle")
@@ -85,7 +91,7 @@ struct MenuBarExtraView: View {
             }
             .keyboardShortcut("q")
         }
-        .frame(width: 320)
+        .frame(width: UIConstants.menuBarWidth)
         .padding(.vertical, 8)
     }
 }

--- a/Sources/MenuBarApp/PullRequestViewModel.swift
+++ b/Sources/MenuBarApp/PullRequestViewModel.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import Combine
+
+@MainActor
+class PullRequestViewModel: ObservableObject {
+    @Published var pullRequests: [GitHubPullRequest] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    
+    private let apiService = GitHubAPIService.shared
+    private let appSettings = AppSettings.shared
+    private var refreshTimer: Timer?
+    
+    init() {
+        startAutoRefresh()
+    }
+    
+    deinit {
+        refreshTimer?.invalidate()
+    }
+    
+    func fetchPullRequests() async {
+        guard let token = appSettings.getAPIKey() else {
+            errorMessage = "No API key configured"
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            let prs = try await apiService.fetchOpenPullRequests(token: token)
+            pullRequests = prs
+            errorMessage = nil
+        } catch {
+            pullRequests = []
+            if let gitHubError = error as? GitHubAPIError {
+                errorMessage = gitHubError.userFriendlyDescription
+            } else if let urlError = error as? URLError {
+                switch urlError.code {
+                case .notConnectedToInternet:
+                    errorMessage = "No internet connection"
+                case .timedOut:
+                    errorMessage = "Request timed out. Please try again."
+                case .cannotFindHost, .cannotConnectToHost:
+                    errorMessage = "Cannot connect to GitHub. Check your network."
+                default:
+                    errorMessage = "Network error: \(urlError.localizedDescription)"
+                }
+            } else {
+                errorMessage = "Failed to fetch pull requests: \(error.localizedDescription)"
+            }
+        }
+        
+        isLoading = false
+    }
+    
+    func startAutoRefresh() {
+        refreshTimer?.invalidate()
+        
+        // Initial fetch
+        Task {
+            await fetchPullRequests()
+        }
+        
+        // Refresh every 5 minutes
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
+            Task { @MainActor in
+                await self.fetchPullRequests()
+            }
+        }
+    }
+    
+    func refresh() {
+        Task {
+            await fetchPullRequests()
+        }
+    }
+}

--- a/Tests/MenuBarAppTests/BasicTests.swift
+++ b/Tests/MenuBarAppTests/BasicTests.swift
@@ -3,6 +3,34 @@
 
 import Foundation
 
+// Mock structure for testing repository name parsing
+struct MockGitHubPullRequest {
+    let repositoryUrl: String
+    
+    var repositoryName: String? {
+        // Extract repo name from repository_url using robust regex parsing
+        // Format: https://api.github.com/repos/owner/repo
+        let pattern = #"^https://api\.github\.com/repos/[^/]+/([^/]+)(?:/.*)?$"#
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let range = NSRange(repositoryUrl.startIndex..<repositoryUrl.endIndex, in: repositoryUrl)
+            if let match = regex.firstMatch(in: repositoryUrl, options: [], range: range) {
+                let repoRange = Range(match.range(at: 1), in: repositoryUrl)
+                if let repoRange = repoRange {
+                    return String(repositoryUrl[repoRange])
+                }
+            }
+        } catch {
+            // Fallback to original URL parsing if regex fails
+            if let url = URL(string: repositoryUrl),
+               url.pathComponents.count >= 4 {
+                return url.pathComponents[3]
+            }
+        }
+        return nil
+    }
+}
+
 struct BasicTests {
     static func testBasicMath() -> Bool {
         return 2 + 2 == 4
@@ -14,6 +42,30 @@ struct BasicTests {
     
     static func testBooleanLogic() -> Bool {
         return true && true
+    }
+    
+    static func testRepositoryNameParsing() -> Bool {
+        // Create a test GitHubPullRequest with various URL formats
+        let testCases = [
+            ("https://api.github.com/repos/owner/repo", "repo"),
+            ("https://api.github.com/repos/microsoft/vscode", "vscode"),
+            ("https://api.github.com/repos/owner/repo-with-dashes", "repo-with-dashes"),
+            ("https://api.github.com/repos/owner/repo.with.dots", "repo.with.dots"),
+            ("invalid-url", nil),
+            ("", nil)
+        ]
+        
+        for (url, expected) in testCases {
+            let mockPR = MockGitHubPullRequest(repositoryUrl: url)
+            let actual = mockPR.repositoryName
+            
+            if actual != expected {
+                print("Repository name parsing failed: URL=\(url), expected=\(expected ?? "nil"), actual=\(actual ?? "nil")")
+                return false
+            }
+        }
+        
+        return true
     }
     
     static func runAll() -> Bool {
@@ -39,6 +91,13 @@ struct BasicTests {
             print("✓ testBooleanLogic passed")
         } else {
             print("✗ testBooleanLogic failed")
+            allPassed = false
+        }
+        
+        if testRepositoryNameParsing() {
+            print("✓ testRepositoryNameParsing passed")
+        } else {
+            print("✗ testRepositoryNameParsing failed")
             allPassed = false
         }
         


### PR DESCRIPTION
## Summary
- Implemented functionality to display all open pull requests in the menu bar
- PRs are fetched from GitHub API and displayed with clickable links
- Added auto-refresh every 5 minutes to keep PR list up to date

## Changes
- Added `GitHubPullRequest` model to represent PR data from GitHub Search API
- Implemented `fetchOpenPullRequests` method in `GitHubAPIService` to fetch user's open PRs
- Created `PullRequestViewModel` to manage PR data and handle auto-refresh
- Updated menu bar UI to display PR list with title, number, repo name, and last updated time
- Added detailed error messages for better debugging and user guidance
- Fixed JSON decoding to handle GitHub Search API response format

## Features
- Shows all open PRs authored by the authenticated user
- Displays draft PR indicator
- Click any PR to open it in the browser
- Manual refresh button available
- Auto-refreshes every 5 minutes
- Shows loading indicator during fetch
- Handles errors with actionable messages

## Test plan
- [x] Verify PRs are displayed in the menu bar
- [x] Click on a PR to ensure it opens in the browser
- [x] Test refresh button functionality
- [x] Verify error messages are shown when API fails
- [x] Check that draft PRs show the draft indicator
- [x] Ensure auto-refresh works after 5 minutes

🤖 Generated with [Claude Code](https://claude.ai/code)