### PR TITLE
fix: improve menu bar padding and spacing for better macOS appearance

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -42,7 +42,7 @@ struct MenuBarExtraView: View {
                         .buttonStyle(.plain)
                     }
                 }
-                .padding(.bottom, 4)
+                .padding(.bottom, 6)
                 
                 Divider()
                 
@@ -59,11 +59,12 @@ struct MenuBarExtraView: View {
                         .frame(maxWidth: .infinity)
                 } else {
                     ScrollView {
-                        VStack(alignment: .leading, spacing: 1) {
+                        VStack(alignment: .leading, spacing: 4) {
                             ForEach(viewModel.pullRequests) { pr in
                                 PullRequestRow(pullRequest: pr)
                             }
                         }
+                        .padding(.vertical, 4)
                     }
                     .frame(maxHeight: UIConstants.scrollViewMaxHeight)
                 }
@@ -92,7 +93,8 @@ struct MenuBarExtraView: View {
             .keyboardShortcut("q")
         }
         .frame(width: UIConstants.menuBarWidth)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
     }
 }
 
@@ -139,8 +141,8 @@ struct PullRequestRow: View {
                         .foregroundColor(.secondary)
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
Fixes padding and margins in the menu bar app to provide proper spacing and prevent text from running against edges.

Changes:
- Add horizontal padding to main container
- Improve list item spacing between PR rows
- Add proper ScrollView content padding
- Balance individual row padding
- Enhance header section separation

Fixes #10

Generated with [Claude Code](https://claude.ai/code)