### PR TITLE
Add CI/CD check status indicators to pull requests

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -124,9 +124,13 @@ struct PullRequestRow: View {
                 }
                 
                 HStack {
-                    Text("#\(pullRequest.number)")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+                    HStack(spacing: 4) {
+                        Text("#\(pullRequest.number)")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                        
+                        CheckStatusIndicator(status: pullRequest.checkStatus)
+                    }
                     
                     if let repoName = pullRequest.repositoryName {
                         Text(repoName)
@@ -160,5 +164,49 @@ struct PullRequestRow: View {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+struct CheckStatusIndicator: View {
+    let status: CheckStatus
+    
+    var body: some View {
+        HStack(spacing: 2) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 6, height: 6)
+            
+            if status != .unknown {
+                Text(statusText)
+                    .font(.caption2)
+                    .foregroundColor(statusColor)
+            }
+        }
+    }
+    
+    private var statusColor: Color {
+        switch status {
+        case .success:
+            return .green
+        case .failed:
+            return .red
+        case .inProgress:
+            return .orange
+        case .unknown:
+            return .secondary
+        }
+    }
+    
+    private var statusText: String {
+        switch status {
+        case .success:
+            return "✓"
+        case .failed:
+            return "✗"
+        case .inProgress:
+            return "⏳"
+        case .unknown:
+            return ""
+        }
     }
 }

--- a/Sources/MenuBarApp/GitHubAPIService.swift
+++ b/Sources/MenuBarApp/GitHubAPIService.swift
@@ -42,6 +42,8 @@ struct GitHubPullRequest: Codable, Identifiable {
     let user: GitHubUser
     let pullRequest: PullRequestInfo?
     let repositoryUrl: String
+    let headSha: String?
+    var checkRuns: [GitHubCheckRun] = []
     
     enum CodingKeys: String, CodingKey {
         case id, number, title, state, draft, user
@@ -50,6 +52,7 @@ struct GitHubPullRequest: Codable, Identifiable {
         case updatedAt = "updated_at"
         case pullRequest = "pull_request"
         case repositoryUrl = "repository_url"
+        case headSha = "head_sha"
     }
     
     var repositoryName: String? {
@@ -74,6 +77,54 @@ struct GitHubPullRequest: Codable, Identifiable {
         }
         return nil
     }
+    
+    var hasFailingChecks: Bool {
+        checkRuns.contains { $0.isFailed }
+    }
+    
+    var hasInProgressChecks: Bool {
+        checkRuns.contains { $0.isInProgress }
+    }
+    
+    var allChecksSuccessful: Bool {
+        !checkRuns.isEmpty && checkRuns.allSatisfy { $0.isSuccessful }
+    }
+    
+    var checkStatus: CheckStatus {
+        if checkRuns.isEmpty {
+            return .unknown
+        }
+        if hasFailingChecks {
+            return .failed
+        }
+        if hasInProgressChecks {
+            return .inProgress
+        }
+        if allChecksSuccessful {
+            return .success
+        }
+        return .unknown
+    }
+}
+
+enum CheckStatus: String, CaseIterable {
+    case success = "success"
+    case failed = "failed"
+    case inProgress = "in_progress"
+    case unknown = "unknown"
+    
+    var displayName: String {
+        switch self {
+        case .success:
+            return "Passing"
+        case .failed:
+            return "Failed"
+        case .inProgress:
+            return "In Progress"
+        case .unknown:
+            return "Unknown"
+        }
+    }
 }
 
 struct PullRequestInfo: Codable {
@@ -83,6 +134,67 @@ struct PullRequestInfo: Codable {
     enum CodingKeys: String, CodingKey {
         case url
         case htmlUrl = "html_url"
+    }
+}
+
+struct GitHubCheckRun: Codable, Identifiable {
+    let id: Int
+    let headSha: String
+    let status: String
+    let conclusion: String?
+    let name: String
+    let startedAt: Date?
+    let completedAt: Date?
+    let output: CheckRunOutput?
+    
+    enum CodingKeys: String, CodingKey {
+        case id, status, conclusion, name, output
+        case headSha = "head_sha"
+        case startedAt = "started_at"
+        case completedAt = "completed_at"
+    }
+    
+    var isComplete: Bool {
+        status == "completed"
+    }
+    
+    var isSuccessful: Bool {
+        conclusion == "success"
+    }
+    
+    var isFailed: Bool {
+        conclusion == "failure"
+    }
+    
+    var isInProgress: Bool {
+        status == "in_progress" || status == "queued"
+    }
+}
+
+struct CheckRunOutput: Codable {
+    let title: String?
+    let summary: String?
+    let annotationsCount: Int?
+    
+    enum CodingKeys: String, CodingKey {
+        case title, summary
+        case annotationsCount = "annotations_count"
+    }
+}
+
+struct GitHubCheckRunsResponse: Codable {
+    let checkRuns: [GitHubCheckRun]
+    
+    enum CodingKeys: String, CodingKey {
+        case checkRuns = "check_runs"
+    }
+}
+
+struct GitHubPullRequestDetails: Codable {
+    let head: PRHead
+    
+    struct PRHead: Codable {
+        let sha: String
     }
 }
 
@@ -251,8 +363,44 @@ class GitHubAPIService: ObservableObject {
         validationResult = nil
     }
     
+    func fetchCheckRuns(for owner: String, repo: String, sha: String, token: String) async throws -> [GitHubCheckRun] {
+        guard let url = URL(string: "\(baseURL)/repos/\(owner)/\(repo)/commits/\(sha)/check-runs") else {
+            throw GitHubAPIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        
+        let (data, response) = try await urlSession.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubAPIError.invalidResponse
+        }
+        
+        try handleAPIResponse(httpResponse)
+        
+        do {
+            let checkRunsResponse = try jsonDecoder.decode(GitHubCheckRunsResponse.self, from: data)
+            return checkRunsResponse.checkRuns
+        } catch {
+            #if DEBUG
+            print("Check runs JSON decoding error: \(error)")
+            if let responseString = String(data: data, encoding: .utf8) {
+                let truncated = String(responseString.prefix(200))
+                print("Response preview: \(truncated)...")
+            }
+            #endif
+            throw error
+        }
+    }
+    
     func fetchOpenPullRequests(token: String) async throws -> [GitHubPullRequest] {
-        guard let url = URL(string: "\(baseURL)/search/issues?q=is:pr+is:open+author:@me&sort=updated&per_page=50") else {
+        // First get user info to get the username
+        let user = try await fetchUser(token: token)
+        
+        guard let url = URL(string: "\(baseURL)/search/issues?q=is:pr+is:open+author:\(user.login)&sort=updated&per_page=50") else {
             throw GitHubAPIError.invalidURL
         }
         
@@ -287,6 +435,27 @@ class GitHubAPIService: ObservableObject {
             #endif
             throw error
         }
+    }
+    
+    func fetchPullRequestDetails(owner: String, repo: String, number: Int, token: String) async throws -> GitHubPullRequestDetails {
+        guard let url = URL(string: "\(baseURL)/repos/\(owner)/\(repo)/pulls/\(number)") else {
+            throw GitHubAPIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        
+        let (data, response) = try await urlSession.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubAPIError.invalidResponse
+        }
+        
+        try handleAPIResponse(httpResponse)
+        
+        return try jsonDecoder.decode(GitHubPullRequestDetails.self, from: data)
     }
     
     private func handleAPIResponse(_ response: HTTPURLResponse) throws {

--- a/Sources/MenuBarApp/PullRequestViewModel.swift
+++ b/Sources/MenuBarApp/PullRequestViewModel.swift
@@ -35,7 +35,49 @@ class PullRequestViewModel: ObservableObject {
         errorMessage = nil
         
         do {
-            let prs = try await apiService.fetchOpenPullRequests(token: token)
+            var prs = try await apiService.fetchOpenPullRequests(token: token)
+            
+            // Fetch check runs for each PR
+            await withTaskGroup(of: (Int, [GitHubCheckRun]?).self) { group in
+                for (index, pr) in prs.enumerated() {
+                    guard let repoName = pr.repositoryName,
+                          let repoOwner = extractOwnerFromRepositoryUrl(pr.repositoryUrl) else {
+                        continue
+                    }
+                    
+                    group.addTask {
+                        do {
+                            // First get the PR details to get the head SHA
+                            let prDetails = try await self.apiService.fetchPullRequestDetails(
+                                owner: repoOwner,
+                                repo: repoName,
+                                number: pr.number,
+                                token: token
+                            )
+                            
+                            let checkRuns = try await self.apiService.fetchCheckRuns(
+                                for: repoOwner,
+                                repo: repoName,
+                                sha: prDetails.head.sha,
+                                token: token
+                            )
+                            return (index, checkRuns)
+                        } catch {
+                            #if DEBUG
+                            print("Failed to fetch check runs for PR \(pr.number): \(error)")
+                            #endif
+                            return (index, nil)
+                        }
+                    }
+                }
+                
+                for await (index, checkRuns) in group {
+                    if let checkRuns = checkRuns {
+                        prs[index].checkRuns = checkRuns
+                    }
+                }
+            }
+            
             pullRequests = prs
             errorMessage = nil
         } catch {
@@ -82,5 +124,28 @@ class PullRequestViewModel: ObservableObject {
         Task {
             await fetchPullRequests()
         }
+    }
+    
+    private func extractOwnerFromRepositoryUrl(_ repositoryUrl: String) -> String? {
+        // Extract owner from repository_url using robust regex parsing
+        // Format: https://api.github.com/repos/owner/repo
+        let pattern = #"^https://api\.github\.com/repos/([^/]+)/[^/]+(?:/.*)?$"#
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let range = NSRange(repositoryUrl.startIndex..<repositoryUrl.endIndex, in: repositoryUrl)
+            if let match = regex.firstMatch(in: repositoryUrl, options: [], range: range) {
+                let ownerRange = Range(match.range(at: 1), in: repositoryUrl)
+                if let ownerRange = ownerRange {
+                    return String(repositoryUrl[ownerRange])
+                }
+            }
+        } catch {
+            // Fallback to original URL parsing if regex fails
+            if let url = URL(string: repositoryUrl),
+               url.pathComponents.count >= 3 {
+                return url.pathComponents[2]
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Summary
- Adds visual indicators showing CI/CD check status for each pull request in the menu bar
- Displays colored status icons: green ✓ for passing, red ✗ for failed, orange ⏳ for in-progress, gray for unknown
- Fetches check run data from GitHub API in parallel for optimal performance

## Changes Made
- **Data Models**: Added `GitHubCheckRun`, `CheckRunOutput`, and `CheckStatus` structs
- **API Integration**: Implemented `fetchCheckRuns()` and `fetchPullRequestDetails()` methods
- **UI Component**: Created `CheckStatusIndicator` view with colored status icons
- **Performance**: Uses TaskGroup for parallel API requests to fetch check status efficiently

## Test Plan
- [x] Build succeeds in debug and release modes
- [x] App launches and displays PRs with check status indicators
- [x] Status icons show correct colors based on CI/CD state
- [x] Handles missing or failed check run API calls gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)