### PR TITLE
Add configurable search queries with grouped menu display

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: macos-latest
@@ -28,5 +33,6 @@ jobs:
       if: success() || failure()
       with:
         path: TestResults.xcresult
+        token: ${{ secrets.GITHUB_TOKEN }}
         show-passed-tests: false
         show-code-coverage: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         show-passed-tests: false
         show-code-coverage: false
+        upload-bundles: never

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,24 +23,10 @@ jobs:
           -derivedDataPath ./DerivedData
       continue-on-error: true
     
-    - name: Check if test results exist
-      run: |
-        echo "Checking for test results..."
-        ls -la ./
-        if [ -d "./TestResults.xcresult" ]; then
-          echo "TestResults.xcresult found"
-          ls -la ./TestResults.xcresult/
-        else
-          echo "TestResults.xcresult not found"
-          echo "Looking for any xcresult files:"
-          find . -name "*.xcresult" -type d
-        fi
-    
-    - name: Parse test results
-      uses: dorny/test-reporter@v1
+    - name: Publish test results
+      uses: kishikawakatsumi/xcresulttool@v1
       if: success() || failure()
       with:
-        name: 'Test Results'
-        path: './TestResults.xcresult'
-        reporter: 'swift-xunit'
-        fail-on-error: false
+        path: TestResults.xcresult
+        show-passed-tests: false
+        show-code-coverage: false

--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -52,16 +52,52 @@ struct MenuBarExtraView: View {
                         .font(.caption)
                         .padding()
                         .frame(maxWidth: .infinity)
-                } else if viewModel.pullRequests.isEmpty && !viewModel.isLoading {
-                    Text("No open pull requests")
+                } else if viewModel.queryResults.isEmpty && !viewModel.isLoading {
+                    Text("No pull requests found")
                         .foregroundColor(.secondary)
                         .padding(.vertical, 20)
                         .frame(maxWidth: .infinity)
                 } else {
                     ScrollView {
-                        VStack(alignment: .leading, spacing: 4) {
-                            ForEach(viewModel.pullRequests) { pr in
-                                PullRequestRow(pullRequest: pr)
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(viewModel.queryResults) { queryResult in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    if !queryResult.query.title.isEmpty {
+                                        HStack {
+                                            Text(queryResult.query.title)
+                                                .font(.caption)
+                                                .bold()
+                                                .foregroundColor(.secondary)
+                                            
+                                            Spacer()
+                                            
+                                            if !queryResult.pullRequests.isEmpty {
+                                                Text("\(queryResult.pullRequests.count)")
+                                                    .font(.caption2)
+                                                    .foregroundColor(.secondary)
+                                                    .padding(.horizontal, 6)
+                                                    .padding(.vertical, 2)
+                                                    .background(Color.secondary.opacity(0.2))
+                                                    .cornerRadius(8)
+                                            }
+                                        }
+                                        .padding(.horizontal, 8)
+                                        .padding(.top, queryResult.query.id == viewModel.queryResults.first?.query.id ? 0 : 8)
+                                    }
+                                    
+                                    if queryResult.pullRequests.isEmpty {
+                                        Text("No PRs found for this query")
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                            .italic()
+                                            .padding(.horizontal, 16)
+                                            .padding(.vertical, 4)
+                                    } else {
+                                        ForEach(queryResult.pullRequests) { pr in
+                                            PullRequestRow(pullRequest: pr)
+                                        }
+                                    }
+                                }
                             }
                         }
                         .padding(.vertical, 4)

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -7,70 +7,36 @@ struct SettingsView: View {
     @State private var showAPIKey: Bool = false
     @State private var showSaveAlert: Bool = false
     @State private var saveSuccess: Bool = false
+    @State private var selectedTab: SettingsTab = .api
+    
+    enum SettingsTab: String, CaseIterable {
+        case api = "API"
+        case queries = "Queries"
+    }
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text("GitHub API Settings")
-                .font(.title2)
-                .bold()
-            
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Personal Access Token")
-                    .font(.headline)
-                
-                HStack {
-                    if showAPIKey {
-                        TextField("Enter your GitHub personal access token", text: $apiKey)
-                            .textFieldStyle(.roundedBorder)
-                    } else {
-                        SecureField("Enter your GitHub personal access token", text: $apiKey)
-                            .textFieldStyle(.roundedBorder)
-                    }
-                    
-                    Button(action: { showAPIKey.toggle() }) {
-                        Image(systemName: showAPIKey ? "eye.slash" : "eye")
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
+        VStack(alignment: .leading, spacing: 0) {
+            Picker("Settings", selection: $selectedTab) {
+                ForEach(SettingsTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
                 }
-                
-                Text("You can create a personal access token at github.com/settings/tokens")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
             }
+            .pickerStyle(.segmented)
+            .padding(.bottom, 20)
             
-            HStack {
-                Button("Save") {
-                    saveAPIKey()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(apiKey.isEmpty)
-                
-                Button("Test Token") {
-                    Task {
-                        await githubService.validateToken(apiKey)
-                    }
-                }
-                .disabled(apiKey.isEmpty || githubService.isValidating)
-                
-                if appSettings.hasAPIKey {
-                    Button("Remove Saved Token") {
-                        removeAPIKey()
-                    }
-                    .foregroundColor(.red)
-                }
-                
-                Spacer()
+            switch selectedTab {
+            case .api:
+                APISettingsView(
+                    apiKey: $apiKey,
+                    showAPIKey: $showAPIKey,
+                    showSaveAlert: $showSaveAlert,
+                    saveSuccess: $saveSuccess,
+                    saveAPIKey: saveAPIKey,
+                    removeAPIKey: removeAPIKey
+                )
+            case .queries:
+                QueriesSettingsView()
             }
-            
-            if appSettings.hasAPIKey && apiKey.isEmpty {
-                Label("API key is already saved in Keychain", systemImage: "checkmark.circle.fill")
-                    .foregroundColor(.green)
-                    .font(.caption)
-            }
-            
-            // Token validation results
-            TokenValidationResultView()
         }
         .padding(20)
         .frame(width: 500)
@@ -248,5 +214,244 @@ struct TokenValidationResultView: View {
         .padding()
         .background(Color.red.opacity(0.1))
         .cornerRadius(8)
+    }
+}
+
+struct APISettingsView: View {
+    @StateObject private var appSettings = AppSettings.shared
+    @StateObject private var githubService = GitHubAPIService.shared
+    
+    @Binding var apiKey: String
+    @Binding var showAPIKey: Bool
+    @Binding var showSaveAlert: Bool
+    @Binding var saveSuccess: Bool
+    
+    let saveAPIKey: () -> Void
+    let removeAPIKey: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("GitHub API Settings")
+                .font(.title2)
+                .bold()
+            
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Personal Access Token")
+                    .font(.headline)
+                
+                HStack {
+                    if showAPIKey {
+                        TextField("Enter your GitHub personal access token", text: $apiKey)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        SecureField("Enter your GitHub personal access token", text: $apiKey)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    
+                    Button(action: { showAPIKey.toggle() }) {
+                        Image(systemName: showAPIKey ? "eye.slash" : "eye")
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                
+                Text("You can create a personal access token at github.com/settings/tokens")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            HStack {
+                Button("Save") {
+                    saveAPIKey()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(apiKey.isEmpty)
+                
+                Button("Test Token") {
+                    Task {
+                        await githubService.validateToken(apiKey)
+                    }
+                }
+                .disabled(apiKey.isEmpty || githubService.isValidating)
+                
+                if appSettings.hasAPIKey {
+                    Button("Remove Saved Token") {
+                        removeAPIKey()
+                    }
+                    .foregroundColor(.red)
+                }
+                
+                Spacer()
+            }
+            
+            if appSettings.hasAPIKey && apiKey.isEmpty {
+                Label("API key is already saved in Keychain", systemImage: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                    .font(.caption)
+            }
+            
+            TokenValidationResultView()
+        }
+    }
+}
+
+struct QueriesSettingsView: View {
+    @StateObject private var appSettings = AppSettings.shared
+    @State private var editingQuery: QueryConfiguration?
+    @State private var showingSuggestions = false
+    @State private var newQueryTitle = ""
+    @State private var newQueryText = ""
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack {
+                Text("Search Queries")
+                    .font(.title2)
+                    .bold()
+                
+                Spacer()
+                
+                Menu {
+                    ForEach(QueryConfiguration.suggestedQueries) { suggestion in
+                        Button(suggestion.title) {
+                            appSettings.addQuery(suggestion)
+                        }
+                        .disabled(appSettings.queries.contains(where: { $0.query == suggestion.query }))
+                    }
+                } label: {
+                    Image(systemName: "plus.circle")
+                }
+                .menuStyle(.borderlessButton)
+            }
+            
+            Text("Configure custom search queries to organize your pull requests")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(Array(appSettings.queries.enumerated()), id: \.element.id) { index, query in
+                        QueryRowView(
+                            query: query,
+                            onEdit: { editingQuery = query },
+                            onDelete: { appSettings.removeQuery(at: index) }
+                        )
+                    }
+                    
+                    if appSettings.queries.isEmpty {
+                        Text("No queries configured")
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                            .padding(.vertical, 20)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .frame(maxHeight: 300)
+        }
+        .sheet(item: $editingQuery) { query in
+            QueryEditSheet(
+                query: query,
+                onSave: { updatedQuery in
+                    if let index = appSettings.queries.firstIndex(where: { $0.id == query.id }) {
+                        appSettings.updateQuery(at: index, with: updatedQuery)
+                    }
+                    editingQuery = nil
+                }
+            )
+        }
+    }
+}
+
+struct QueryRowView: View {
+    let query: QueryConfiguration
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(query.title)
+                    .font(.headline)
+                
+                Text(query.query)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+            
+            Spacer()
+            
+            HStack(spacing: 8) {
+                Button("Edit") { onEdit() }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.blue)
+                
+                Button("Delete") { onDelete() }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.red)
+            }
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.1))
+        .cornerRadius(8)
+    }
+}
+
+struct QueryEditSheet: View {
+    @State private var title: String
+    @State private var query: String
+    
+    let onSave: (QueryConfiguration) -> Void
+    
+    init(query: QueryConfiguration, onSave: @escaping (QueryConfiguration) -> Void) {
+        self._title = State(initialValue: query.title)
+        self._query = State(initialValue: query.query)
+        self.onSave = onSave
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Edit Query")
+                .font(.title2)
+                .bold()
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Title:")
+                    .font(.headline)
+                TextField("Query title", text: $title)
+                    .textFieldStyle(.roundedBorder)
+            }
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Query:")
+                    .font(.headline)
+                TextField("GitHub search query", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                
+                Text("Examples: is:open is:pr author:@me, is:open is:pr review-requested:@me")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            HStack {
+                Button("Cancel") {
+                    if let window = NSApp.keyWindow {
+                        window.close()
+                    }
+                }
+                
+                Spacer()
+                
+                Button("Save") {
+                    let updatedQuery = QueryConfiguration(title: title, query: query)
+                    onSave(updatedQuery)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(title.isEmpty || query.isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
     }
 }


### PR DESCRIPTION
## Summary

This PR implements configurable search queries that allow users to organize pull requests with custom GitHub search queries and display them grouped in the menu bar.

### Key Features:
• **QueryConfiguration model** - Stores title and query pairs with default "My Open PRs" query
• **Tabbed Settings UI** - New "Queries" tab for managing search configurations  
• **Suggested queries dropdown** - Quick-add common queries (Review Requests, Team PRs, Draft PRs, etc.)
• **Enhanced API service** - New `searchPullRequests()` method with custom query support
• **Grouped menu display** - PRs organized by query with section headers and count badges
• **Full CRUD operations** - Add, edit, delete queries with persistence to UserDefaults
• **Backward compatibility** - Existing PR display logic preserved

### Technical Implementation:
- Added `QueryConfiguration` struct with Codable support and suggested queries
- Extended `AppSettings` with query management methods and UserDefaults persistence
- Updated `PullRequestViewModel` with `QueryResult` structure for grouped data
- Enhanced `GitHubAPIService` with parameterized search endpoint
- Redesigned menu bar UI with section headers, counts, and empty state handling
- Split Settings into tabbed interface with dedicated query management views

### User Experience:
1. **Setup** - App ships with default "My Open PRs" query pre-configured
2. **Management** - Preferences → Queries tab for full query CRUD operations
3. **Quick-add** - Plus button menu with suggested common queries
4. **Display** - Menu bar shows PRs grouped by query titles with counts
5. **Navigation** - Same click-to-open PR functionality preserved

## Test plan

- [x] Build compiles successfully
- [x] App launches and menu bar integration works
- [x] Default query ("My Open PRs") is pre-configured on first launch
- [x] Settings UI displays tabbed interface (API + Queries)
- [x] Query management (add/edit/delete) works in Preferences
- [x] Suggested queries dropdown functions correctly
- [x] Menu bar displays grouped PRs with section headers
- [x] PR counts and empty states display properly
- [x] Existing functionality (API setup, PR status indicators) preserved
- [ ] Manual testing with actual GitHub API and multiple queries
- [ ] Verify query persistence across app restarts
- [ ] Test edge cases (empty queries, API failures, malformed queries)

🤖 Generated with [Claude Code](https://claude.ai/code)