### PR TITLE
feat: add submenu for individual CI/CD checks

### DIFF
--- a/Sources/MenuBarApp/GitHubAPIService.swift
+++ b/Sources/MenuBarApp/GitHubAPIService.swift
@@ -152,12 +152,16 @@ struct GitHubCheckRun: Codable, Identifiable {
     let startedAt: Date?
     let completedAt: Date?
     let output: CheckRunOutput?
+    let htmlUrl: String?
+    let detailsUrl: String?
     
     enum CodingKeys: String, CodingKey {
         case id, status, conclusion, name, output
         case headSha = "head_sha"
         case startedAt = "started_at"
         case completedAt = "completed_at"
+        case htmlUrl = "html_url"
+        case detailsUrl = "details_url"
     }
     
     var isComplete: Bool {


### PR DESCRIPTION
## Summary
- Add submenu functionality for individual CI/CD checks when hovering over check status
- Each submenu item shows the check name and individual status (passing/failing/in progress)
- Clicking a check opens its details page in the browser

## Changes Made
- **Enhanced GitHubCheckRun model**: Added `htmlUrl` and `detailsUrl` fields to capture GitHub's check run URLs
- **New CheckStatusMenu component**: Shows submenu when check runs are available, replacing the basic status indicator
- **New CheckRunStatusIcon component**: Displays individual check status with color-coded icons (✓, ✗, ⏳, ?)
- **Browser integration**: Opens specific check details in browser when clicked, preferring GitHub's native check page

## User Experience
When a PR has CI/CD checks:
1. Hover over the check status indicator → submenu appears
2. Each menu item shows: check name + individual status
3. Click any check → opens that specific check's page in browser
4. Works for all check statuses (not just failures)

## Test Plan
- [x] Build compiles successfully
- [x] All existing tests pass
- [x] Submenu appears for PRs with check runs
- [x] Individual checks show correct status indicators
- [x] Clicking checks opens correct URLs in browser
- [x] PRs without check runs show normal status indicator

🤖 Generated with [Claude Code](https://claude.ai/code)