### PR TITLE
Convert to native macOS menu bar style

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -14,7 +14,7 @@ struct MenuBarApp: App {
         MenuBarExtra("GitHub PRs", systemImage: "arrow.triangle.pull") {
             MenuBarExtraView()
         }
-        .menuBarExtraStyle(.window)
+        .menuBarExtraStyle(.menu)
     }
 }
 
@@ -23,218 +23,68 @@ struct MenuBarExtraView: View {
     @StateObject private var viewModel = PullRequestViewModel()
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if appSettings.hasAPIKey {
-                HStack {
-                    Text("GitHub PRs")
-                        .font(.headline)
-                    
-                    Spacer()
-                    
-                    if viewModel.isLoading {
-                        ProgressView()
-                            .scaleEffect(0.7)
-                    } else {
-                        Button(action: { viewModel.refresh() }) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.caption)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.bottom, 6)
-                
-                Divider()
-                
-                if let error = viewModel.errorMessage {
-                    Text(error)
-                        .foregroundColor(.red)
-                        .font(.caption)
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                } else if viewModel.queryResults.isEmpty && !viewModel.isLoading {
-                    Text("No pull requests found")
-                        .foregroundColor(.secondary)
-                        .padding(.vertical, 20)
-                        .frame(maxWidth: .infinity)
-                } else {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(viewModel.queryResults) { queryResult in
-                                VStack(alignment: .leading, spacing: 4) {
-                                    if !queryResult.query.title.isEmpty {
-                                        HStack {
-                                            Text(queryResult.query.title)
-                                                .font(.caption)
-                                                .bold()
-                                                .foregroundColor(.secondary)
-                                            
-                                            Spacer()
-                                            
-                                            if !queryResult.pullRequests.isEmpty {
-                                                Text("\(queryResult.pullRequests.count)")
-                                                    .font(.caption2)
-                                                    .foregroundColor(.secondary)
-                                                    .padding(.horizontal, 6)
-                                                    .padding(.vertical, 2)
-                                                    .background(Color.secondary.opacity(0.2))
-                                                    .cornerRadius(8)
-                                            }
-                                        }
-                                        .padding(.horizontal, 8)
-                                        .padding(.top, queryResult.query.id == viewModel.queryResults.first?.query.id ? 0 : 8)
-                                    }
-                                    
-                                    if queryResult.pullRequests.isEmpty {
-                                        Text("No PRs found for this query")
-                                            .font(.caption2)
-                                            .foregroundColor(.secondary)
-                                            .italic()
-                                            .padding(.horizontal, 16)
-                                            .padding(.vertical, 4)
-                                    } else {
-                                        ForEach(queryResult.pullRequests) { pr in
-                                            PullRequestRow(pullRequest: pr)
-                                        }
-                                    }
+        if appSettings.hasAPIKey {
+            if let error = viewModel.errorMessage {
+                Text("Error: \(error)")
+                    .disabled(true)
+            } else if viewModel.queryResults.isEmpty && !viewModel.isLoading {
+                Text("No pull requests found")
+                    .disabled(true)
+            } else {
+                ForEach(viewModel.queryResults) { queryResult in
+                    if !queryResult.query.title.isEmpty {
+                        Section(queryResult.query.title) {
+                            if queryResult.pullRequests.isEmpty {
+                                Text("No PRs found")
+                                    .disabled(true)
+                            } else {
+                                ForEach(queryResult.pullRequests) { pr in
+                                    PullRequestMenuItem(pullRequest: pr)
                                 }
                             }
                         }
-                        .padding(.vertical, 4)
+                    } else {
+                        ForEach(queryResult.pullRequests) { pr in
+                            PullRequestMenuItem(pullRequest: pr)
+                        }
                     }
-                    .frame(maxHeight: UIConstants.scrollViewMaxHeight)
                 }
-            } else {
-                Label("No API Key Configured", systemImage: "exclamationmark.triangle")
-                    .foregroundColor(.orange)
-                    .padding(.vertical, 8)
-                
-                Text("Please configure your GitHub API key in Preferences")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
             }
             
             Divider()
             
-            Button("Preferences...") {
-                appSettings.openSettings()
+            Button("Refresh") {
+                viewModel.refresh()
             }
-            .keyboardShortcut(",", modifiers: .command)
+            .keyboardShortcut("r")
+            .disabled(viewModel.isLoading)
+        } else {
+            Text("No API Key Configured")
+                .disabled(true)
             
-            Button("Quit") {
-                NSApplication.shared.terminate(nil)
-            }
-            .keyboardShortcut("q")
+            Text("Configure in Preferences...")
+                .disabled(true)
         }
-        .frame(width: UIConstants.menuBarWidth)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        
+        Divider()
+        
+        Button("Preferences...") {
+            appSettings.openSettings()
+        }
+        .keyboardShortcut(",", modifiers: .command)
+        
+        Button("Quit") {
+            NSApplication.shared.terminate(nil)
+        }
+        .keyboardShortcut("q")
     }
 }
 
-struct PullRequestRow: View {
+struct PullRequestMenuItem: View {
     let pullRequest: GitHubPullRequest
     
-    var body: some View {
-        Button(action: {
-            if let url = URL(string: pullRequest.htmlUrl) {
-                NSWorkspace.shared.open(url)
-            }
-        }) {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    if pullRequest.draft {
-                        Image(systemName: "doc.text")
-                            .foregroundColor(.secondary)
-                            .font(.caption)
-                    }
-                    
-                    Text(pullRequest.title)
-                        .font(.system(size: 12))
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                    
-                    Spacer()
-                }
-                
-                HStack {
-                    HStack(spacing: 4) {
-                        Text("#\(pullRequest.number)")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                        
-                        CheckStatusMenu(pullRequest: pullRequest)
-                    }
-                    
-                    if let repoName = pullRequest.repositoryName {
-                        Text(repoName)
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                    
-                    Spacer()
-                    
-                    Text(relativeTime(from: pullRequest.updatedAt))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .buttonStyle(.plain)
-        .background(Color.gray.opacity(0.0001))
-        .onHover { isHovered in
-            if isHovered {
-                NSCursor.pointingHand.push()
-            } else {
-                NSCursor.pop()
-            }
-        }
-    }
-    
-    private func relativeTime(from date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
-    }
-}
-
-struct CheckStatusIndicator: View {
-    let status: CheckStatus
-    
-    var body: some View {
-        HStack(spacing: 2) {
-            Circle()
-                .fill(statusColor)
-                .frame(width: 6, height: 6)
-            
-            if status != .unknown {
-                Text(statusText)
-                    .font(.caption2)
-                    .foregroundColor(statusColor)
-            }
-        }
-    }
-    
-    private var statusColor: Color {
-        switch status {
-        case .success:
-            return .green
-        case .failed:
-            return .red
-        case .inProgress:
-            return .orange
-        case .unknown:
-            return .secondary
-        }
-    }
-    
-    private var statusText: String {
-        switch status {
+    private var statusSymbol: String {
+        switch pullRequest.checkStatus {
         case .success:
             return "✓"
         case .failed:
@@ -242,34 +92,57 @@ struct CheckStatusIndicator: View {
         case .inProgress:
             return "⏳"
         case .unknown:
-            return ""
+            return pullRequest.draft ? "📝" : "•"
         }
     }
-}
-
-struct CheckStatusMenu: View {
-    let pullRequest: GitHubPullRequest
     
     var body: some View {
         if !pullRequest.checkRuns.isEmpty {
             Menu {
+                Button(action: {
+                    if let url = URL(string: pullRequest.htmlUrl) {
+                        NSWorkspace.shared.open(url)
+                    }
+                }) {
+                    Text("Open Pull Request")
+                }
+                
+                Divider()
+                
                 ForEach(pullRequest.checkRuns) { checkRun in
                     Button(action: {
                         openCheckRun(checkRun)
                     }) {
-                        HStack {
-                            Text(checkRun.name)
-                            Spacer()
-                            CheckRunStatusIcon(checkRun: checkRun)
-                        }
+                        Text("\(checkRunStatusSymbol(checkRun)) \(checkRun.name)")
                     }
                 }
             } label: {
-                CheckStatusIndicator(status: pullRequest.checkStatus)
+                HStack {
+                    Text("\(statusSymbol) \(pullRequest.title)")
+                    Spacer()
+                    if let repoName = pullRequest.repositoryName {
+                        Text("\(repoName) #\(pullRequest.number)")
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                    }
+                }
             }
-            .menuStyle(.borderlessButton)
         } else {
-            CheckStatusIndicator(status: pullRequest.checkStatus)
+            Button(action: {
+                if let url = URL(string: pullRequest.htmlUrl) {
+                    NSWorkspace.shared.open(url)
+                }
+            }) {
+                HStack {
+                    Text("\(statusSymbol) \(pullRequest.title)")
+                    Spacer()
+                    if let repoName = pullRequest.repositoryName {
+                        Text("\(repoName) #\(pullRequest.number)")
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                    }
+                }
+            }
         }
     }
     
@@ -280,20 +153,75 @@ struct CheckStatusMenu: View {
             NSWorkspace.shared.open(url)
         }
     }
+    
+    private func checkRunStatusSymbol(_ checkRun: GitHubCheckRun) -> String {
+        if checkRun.isSuccessful {
+            return "✓"
+        } else if checkRun.isFailed {
+            return "✗"
+        } else if checkRun.isInProgress {
+            return "⏳"
+        } else {
+            return "?"
+        }
+    }
 }
+
+struct CheckStatusIcon: View {
+    let status: CheckStatus
+    
+    var body: some View {
+        Image(systemName: iconName)
+            .foregroundColor(statusColor)
+            .font(.caption)
+    }
+    
+    private var iconName: String {
+        switch status {
+        case .success:
+            return "checkmark.circle.fill"
+        case .failed:
+            return "xmark.circle.fill"
+        case .inProgress:
+            return "clock.fill"
+        case .unknown:
+            return "circle"
+        }
+    }
+    
+    private var statusColor: Color {
+        switch status {
+        case .success:
+            return .green
+        case .failed:
+            return .red
+        case .inProgress:
+            return .orange
+        case .unknown:
+            return .secondary
+        }
+    }
+}
+
 
 struct CheckRunStatusIcon: View {
     let checkRun: GitHubCheckRun
     
     var body: some View {
-        HStack(spacing: 2) {
-            Circle()
-                .fill(statusColor)
-                .frame(width: 6, height: 6)
-            
-            Text(statusText)
-                .font(.caption2)
-                .foregroundColor(statusColor)
+        Image(systemName: iconName)
+            .foregroundColor(statusColor)
+            .font(.caption)
+    }
+    
+    private var iconName: String {
+        if checkRun.isSuccessful {
+            return "checkmark.circle.fill"
+        } else if checkRun.isFailed {
+            return "xmark.circle.fill"
+        } else if checkRun.isInProgress {
+            return "clock.fill"
+        } else {
+            return "questionmark.circle"
         }
     }
     
@@ -306,18 +234,6 @@ struct CheckRunStatusIcon: View {
             return .orange
         } else {
             return .secondary
-        }
-    }
-    
-    private var statusText: String {
-        if checkRun.isSuccessful {
-            return "✓"
-        } else if checkRun.isFailed {
-            return "✗"
-        } else if checkRun.isInProgress {
-            return "⏳"
-        } else {
-            return "?"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Converted from custom window-style menu to native macOS menu bar style for more official appearance
- Added Unicode status symbols to provide visual feedback without custom UI components
- Simplified menu structure to match standard macOS applications

## Changes
- Changed `.menuBarExtraStyle(.window)` to `.menuBarExtraStyle(.menu)`
- Replaced custom `VStack` layout with native menu items and sections
- Added status symbols (✓, ✗, ⏳, 📝) prepended to PR titles
- Converted check runs to submenus with their own status indicators
- Removed custom styling, scroll views, and visual elements

## Test plan
- [x] Build and run the application
- [x] Verify menu appears with native macOS styling
- [x] Check that PR titles show with status symbols
- [x] Test that clicking PRs opens them in browser
- [x] Verify check runs appear in submenus
- [x] Confirm keyboard shortcuts still work (⌘, for Preferences, Q for Quit)

🤖 Generated with [Claude Code](https://claude.ai/code)