### PR TITLE
fix: properly dismiss query edit sheet on cancel

### DIFF
--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -356,7 +356,6 @@ struct QueriesSettingsView: View {
                     if let index = appSettings.queries.firstIndex(where: { $0.id == query.id }) {
                         appSettings.updateQuery(at: index, with: updatedQuery)
                     }
-                    editingQuery = nil
                 }
             )
         }
@@ -401,6 +400,7 @@ struct QueryRowView: View {
 struct QueryEditSheet: View {
     @State private var title: String
     @State private var query: String
+    @Environment(\.dismiss) private var dismiss
     
     let onSave: (QueryConfiguration) -> Void
     
@@ -436,9 +436,7 @@ struct QueryEditSheet: View {
             
             HStack {
                 Button("Cancel") {
-                    if let window = NSApp.keyWindow {
-                        window.close()
-                    }
+                    dismiss()
                 }
                 
                 Spacer()
@@ -446,6 +444,7 @@ struct QueryEditSheet: View {
                 Button("Save") {
                     let updatedQuery = QueryConfiguration(title: title, query: query)
                     onSave(updatedQuery)
+                    dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(title.isEmpty || query.isEmpty)


### PR DESCRIPTION
## Summary
- Fixed issue where the Cancel button in the Query Edit sheet was not properly dismissing the dialog
- The sheet would immediately reopen after clicking Cancel due to improper window closure

## Changes
- Added `@Environment(\.dismiss)` to the `QueryEditSheet` view
- Replaced window closing logic with proper SwiftUI dismiss() calls
- Also added dismiss() to the Save button for consistency
- Removed unnecessary `editingQuery = nil` assignment in the parent view

## Test plan
- [x] Build the app successfully
- [x] Open Settings → Queries tab
- [x] Click Edit on any query (or add one first if none exist)
- [x] Click Cancel and verify the sheet dismisses properly without reopening
- [x] Click Edit again and then Save to verify saving still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)