### PR TITLE
Add configurable refresh intervals and last refresh timestamp

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -30,6 +30,12 @@ struct MenuBarExtraView: View {
     @StateObject private var appSettings = AppSettings.shared
     @ObservedObject var viewModel: PullRequestViewModel
     
+    private func formatLastRefreshTime(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+    
     var body: some View {
         if appSettings.hasAPIKey {
             if let error = viewModel.errorMessage {
@@ -66,6 +72,13 @@ struct MenuBarExtraView: View {
             }
             .keyboardShortcut("r")
             .disabled(viewModel.isLoading)
+            
+            if let lastRefresh = viewModel.lastRefreshTime {
+                Text("Last updated: \(formatLastRefreshTime(lastRefresh))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .disabled(true)
+            }
         } else {
             Text("No API Key Configured")
                 .disabled(true)

--- a/Sources/MenuBarApp/AppSettings.swift
+++ b/Sources/MenuBarApp/AppSettings.swift
@@ -38,10 +38,12 @@ class AppSettings: ObservableObject {
     @Published var hasAPIKey: Bool = false
     @Published var isSettingsPresented: Bool = false
     @Published var queries: [QueryConfiguration] = []
+    @Published var refreshInterval: TimeInterval = 300 // 5 minutes default
     
     private let keychainManager = KeychainManager.shared
     private var settingsWindow: NSWindow?
     private let queriesKey = "configuredQueries"
+    private let refreshIntervalKey = "refreshInterval"
     
     // Testing support
     #if DEBUG
@@ -54,6 +56,7 @@ class AppSettings: ObservableObject {
     private init() {
         checkForExistingAPIKey()
         loadQueries()
+        loadRefreshInterval()
     }
     
     func checkForExistingAPIKey() {
@@ -136,4 +139,31 @@ class AppSettings: ObservableObject {
         queries[index] = query
         saveQueries()
     }
+    
+    func loadRefreshInterval() {
+        let stored = UserDefaults.standard.double(forKey: refreshIntervalKey)
+        if stored > 0 {
+            refreshInterval = stored
+        } else {
+            refreshInterval = 300 // 5 minutes default
+            saveRefreshInterval()
+        }
+    }
+    
+    func saveRefreshInterval() {
+        UserDefaults.standard.set(refreshInterval, forKey: refreshIntervalKey)
+    }
+    
+    func setRefreshInterval(_ interval: TimeInterval) {
+        refreshInterval = interval
+        saveRefreshInterval()
+    }
+    
+    static let refreshIntervalOptions: [(title: String, interval: TimeInterval)] = [
+        ("30 seconds", 30),
+        ("1 minute", 60),
+        ("2 minutes", 120),
+        ("5 minutes", 300),
+        ("60 minutes", 3600)
+    ]
 }

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     enum SettingsTab: String, CaseIterable {
         case api = "API"
         case queries = "Queries"
+        case general = "General"
     }
     
     var body: some View {
@@ -36,6 +37,8 @@ struct SettingsView: View {
                 )
             case .queries:
                 QueriesSettingsView()
+            case .general:
+                GeneralSettingsView()
             }
         }
         .padding(20)
@@ -452,5 +455,43 @@ struct QueryEditSheet: View {
         }
         .padding(20)
         .frame(width: 400)
+    }
+}
+
+struct GeneralSettingsView: View {
+    @StateObject private var appSettings = AppSettings.shared
+    @StateObject private var viewModel = PullRequestViewModel()
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("General Settings")
+                .font(.title2)
+                .bold()
+            
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Refresh Interval")
+                    .font(.headline)
+                
+                Text("How often to automatically check for pull request updates")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                Picker("Refresh Interval", selection: Binding(
+                    get: { appSettings.refreshInterval },
+                    set: { newInterval in
+                        appSettings.setRefreshInterval(newInterval)
+                        viewModel.startAutoRefresh()
+                    }
+                )) {
+                    ForEach(AppSettings.refreshIntervalOptions, id: \.interval) { option in
+                        Text(option.title).tag(option.interval)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: 200, alignment: .leading)
+            }
+            
+            Spacer()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add refresh interval setting in Preferences → General with configurable options (30s, 1m, 2m, 5m, 60m)
- Display "Last updated: X ago" timestamp below refresh button in menu bar using relative time formatting
- Store refresh interval preference persistently in UserDefaults

## Changes Made
- **PullRequestViewModel**: Track `lastRefreshTime` and use configurable refresh interval from settings
- **AppSettings**: Add refresh interval property with persistence and predefined options
- **SettingsView**: New "General" tab with refresh interval dropdown picker
- **App**: Display relative timestamp below refresh button, removed interval menu from main UI

## Test Plan
- [x] Build succeeds without errors
- [x] Refresh interval can be configured in Preferences → General
- [x] Last refresh timestamp displays correctly with relative formatting
- [x] Timer restarts with new interval when changed in preferences
- [x] Setting persists between app launches

🤖 Generated with [Claude Code](https://claude.ai/code)