### PR TITLE
Add GitHub search syntax documentation link

### DIFF
--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -455,6 +455,18 @@ struct QueryEditSheet: View {
                 Text("Examples: is:open is:pr author:@me, is:open is:pr review-requested:@me")
                     .font(.caption)
                     .foregroundColor(.secondary)
+                
+                Link("GitHub search syntax documentation", destination: URL(string: "https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests")!)
+                    .font(.caption)
+                    .foregroundColor(.blue)
+                    .underline()
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.pointingHand.set()
+                        } else {
+                            NSCursor.arrow.set()
+                        }
+                    }
             }
             
             VStack(alignment: .leading, spacing: 12) {


### PR DESCRIPTION
## Summary
- Added a clickable link to GitHub's search syntax documentation in the Edit Query interface
- Link appears after the example queries to help users discover all available search parameters
- Includes proper hover behavior with cursor change and underline styling

## Test plan
- [x] Open Settings → Queries tab
- [x] Click "Edit" on any query or create a new one
- [x] Verify the documentation link appears under the query examples
- [x] Test that the link opens the correct GitHub documentation page
- [x] Verify hover effects work (pointer cursor, underline visible)

🤖 Generated with [Claude Code](https://claude.ai/code)