### PR TITLE
Add drag and drop interface for PR display component ordering

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -173,67 +173,50 @@ struct PullRequestMenuItem: View {
     }
     
     private func buildCompleteText() -> String {
-        var parts: [String] = []
-        var currentGroup: [String] = []
+        var result: [String] = []
         
         for component in queryConfig.componentOrder {
             switch component {
             case .statusSymbol:
-                if !currentGroup.isEmpty {
-                    parts.append(currentGroup.joined(separator: " "))
-                    currentGroup = []
-                }
-                parts.append(statusSymbol)
+                result.append(statusSymbol)
                 
             case .title:
-                if !currentGroup.isEmpty {
-                    parts.append(currentGroup.joined(separator: " "))
-                    currentGroup = []
-                }
-                parts.append(pullRequest.title)
+                result.append(pullRequest.title)
                 
             case .separator:
-                if !currentGroup.isEmpty {
-                    parts.append(currentGroup.joined(separator: " "))
-                    currentGroup = []
-                }
-                // Separator is handled by joining with " – "
+                result.append("–")
                 
             case .orgName:
                 if let orgName = pullRequest.repositoryOwner, !orgName.isEmpty {
-                    currentGroup.append(orgName)
+                    result.append(orgName)
                 }
                 
             case .projectName:
                 if let repoName = pullRequest.repositoryName, !repoName.isEmpty {
-                    currentGroup.append(repoName)
+                    result.append(repoName)
                 }
                 
             case .prNumber:
-                currentGroup.append("#\(pullRequest.number)")
+                result.append("#\(pullRequest.number)")
                 
             case .authorName:
                 if !pullRequest.user.login.isEmpty {
-                    currentGroup.append("@\(pullRequest.user.login)")
+                    result.append("@\(pullRequest.user.login)")
                 }
             }
         }
         
-        if !currentGroup.isEmpty {
-            parts.append(currentGroup.joined(separator: " "))
-        }
-        
-        let result = parts.joined(separator: " – ")
+        let finalResult = result.joined(separator: " ")
         
         #if DEBUG
         print("buildCompleteText for query '\(queryConfig.title)' with component order: \(queryConfig.componentOrder.map(\.rawValue))")
-        print("buildCompleteText result: '\(result)'")
+        print("buildCompleteText result: '\(finalResult)'")
         print("repositoryOwner: \(pullRequest.repositoryOwner ?? "nil")")
         print("repositoryName: \(pullRequest.repositoryName ?? "nil")")
         print("user.login: \(pullRequest.user.login)")
         #endif
         
-        return result
+        return finalResult
     }
     
     private func buildInfoText() -> String {

--- a/Sources/MenuBarApp/AppSettings.swift
+++ b/Sources/MenuBarApp/AppSettings.swift
@@ -74,13 +74,10 @@ struct QueryConfiguration: Codable, Identifiable, Equatable {
             let showPRNumber = try container.decodeIfPresent(Bool.self, forKey: .showPRNumber) ?? true
             let showAuthorName = try container.decodeIfPresent(Bool.self, forKey: .showAuthorName) ?? false
             
-            if showOrgName || showProjectName || showPRNumber || showAuthorName {
-                defaultOrder.append(.separator)
-                if showOrgName { defaultOrder.append(.orgName) }
-                if showProjectName { defaultOrder.append(.projectName) }
-                if showPRNumber { defaultOrder.append(.prNumber) }
-                if showAuthorName { defaultOrder.append(.authorName) }
-            }
+            if showOrgName { defaultOrder.append(.orgName) }
+            if showProjectName { defaultOrder.append(.projectName) }
+            if showPRNumber { defaultOrder.append(.prNumber) }
+            if showAuthorName { defaultOrder.append(.authorName) }
             componentOrder = defaultOrder
         }
         
@@ -117,13 +114,10 @@ struct QueryConfiguration: Codable, Identifiable, Equatable {
             self.componentOrder = order
         } else {
             var defaultOrder: [PRDisplayComponent] = [.statusSymbol, .title]
-            if showOrgName || showProjectName || showPRNumber || showAuthorName {
-                defaultOrder.append(.separator)
-                if showOrgName { defaultOrder.append(.orgName) }
-                if showProjectName { defaultOrder.append(.projectName) }
-                if showPRNumber { defaultOrder.append(.prNumber) }
-                if showAuthorName { defaultOrder.append(.authorName) }
-            }
+            if showOrgName { defaultOrder.append(.orgName) }
+            if showProjectName { defaultOrder.append(.projectName) }
+            if showPRNumber { defaultOrder.append(.prNumber) }
+            if showAuthorName { defaultOrder.append(.authorName) }
             self.componentOrder = defaultOrder
         }
         


### PR DESCRIPTION
## Summary

Replaces the checkbox-based display options with an intuitive drag and drop interface for customizing PR component layout in the menu bar. Users can now visually arrange components exactly how they want them to appear.

### Key Features

- **Interactive Layout Editor**: Drag components directly in a visual preview showing exactly how menu items will look
- **Component Palette**: Horizontal scrollable palette of available components below the layout area  
- **Visual Drop Indicators**: Blue carets show precise drop positions during drag operations
- **Multiple Separators**: Allow adding multiple separator components for custom formatting
- **Reliable Positioning**: Completely rewritten drop logic ensures components land exactly where the visual indicator shows

### Components Available

- Status Symbol (✓, ✗, ⏳, etc.)
- Title (PR title)
- Organization name  
- Project name
- PR Number (#1234)
- Author name (@username)
- Separator (–)

### UX Improvements

- **Tight, polished interface** with reduced spacing and padding
- **Clear labeling** - changed "Preview" to "Layout" for accuracy
- **Multiple interaction methods**: drag & drop, double-click to add, drag back to palette to remove
- **Smooth animations** and visual feedback during interactions
- **Backward compatible** - existing queries automatically migrate from toggles to drag & drop

### Technical Implementation

- Added `PRDisplayComponent` enum with all draggable components
- Extended `QueryConfiguration` with `componentOrder` array and backward compatibility
- Updated `buildCompleteText()` to respect component ordering and separator placement
- Implemented precise drag & drop delegates with proper index calculations
- Added visual drop zone indicators with enter/exit states

## Test plan

- [x] Create/edit queries and verify drag & drop interface appears
- [x] Test dragging components within layout to reorder  
- [x] Test dragging from palette to layout to add components
- [x] Test dragging from layout back to palette to remove components
- [x] Verify separators can be added multiple times
- [x] Confirm menu bar display matches layout editor exactly
- [x] Test backward compatibility with existing saved queries
- [x] Verify build and run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)