### PR TITLE
feat: add branch conflict detection and display

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -119,7 +119,7 @@ struct PullRequestMenuItem: View {
     }
     
     var body: some View {
-        if !pullRequest.checkRuns.isEmpty {
+        if !pullRequest.checkRuns.isEmpty || pullRequest.hasBranchConflicts {
             Menu {
                 Button(action: {
                     if let url = URL(string: pullRequest.htmlUrl) {
@@ -130,6 +130,16 @@ struct PullRequestMenuItem: View {
                 }
                 
                 Divider()
+                
+                // Show branch conflicts if they exist
+                if pullRequest.hasBranchConflicts {
+                    Text("❌ Branch conflicts prevent checks from running")
+                        .disabled(true)
+                    
+                    if !pullRequest.checkRuns.isEmpty {
+                        Divider()
+                    }
+                }
                 
                 ForEach(pullRequest.checkRuns) { checkRun in
                     if checkRun.isGitHubActions && !checkRun.jobs.isEmpty {


### PR DESCRIPTION
## Summary
• Detect PRs with branch conflicts that prevent checks from running  
• Show red cross (❌) status for PRs with merge conflicts
• Add explanatory sub-menu text: "Branch conflicts prevent checks from running"
• Include branch conflicts in pending actions count

## Implementation Details
- Added `mergeable` and `mergeableState` fields to `GitHubPullRequest` model
- Enhanced PR details fetching to include mergeable state information  
- Branch conflicts detected when `mergeable=false` and `mergeableState="dirty"`
- Branch conflicts take precedence over regular check status
- Updated UI to show sub-menu even when no check runs exist but conflicts are present

## Test Plan
- [x] Verified with PR that has merge conflicts (https://github.com/laurenkt/sprout/pull/30)
- [x] Red cross appears in menu bar for conflicted PRs
- [x] Sub-menu shows explanatory text about branch conflicts
- [x] Pending actions count includes conflicted PRs

🤖 Generated with [Claude Code](https://claude.ai/code)