### PR TITLE
feat: enable direct clicking on menu items with sub-menus

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -164,6 +164,8 @@ struct PullRequestMenuItem: View {
                                         }
                                     } label: {
                                         Text("\(jobStatusSymbol(job)) \(job.name)")
+                                    } primaryAction: {
+                                        openWorkflowJob(job)
                                     }
                                 } else {
                                     Button(action: {
@@ -175,6 +177,8 @@ struct PullRequestMenuItem: View {
                             }
                         } label: {
                             Text("\(checkRunStatusSymbol(checkRun)) \(checkRun.name)")
+                        } primaryAction: {
+                            openCheckRun(checkRun)
                         }
                     } else {
                         Button(action: {
@@ -186,6 +190,10 @@ struct PullRequestMenuItem: View {
                 }
             } label: {
                 Text(buildCompleteText())
+            } primaryAction: {
+                if let url = URL(string: pullRequest.htmlUrl) {
+                    NSWorkspace.shared.open(url)
+                }
             }
         } else {
             Button(action: {


### PR DESCRIPTION
## Summary
- Add `primaryAction` to Menu components for PRs, checks, and workflow jobs
- Enable direct clicking on menu items even when they have sub-items
- Improves UX by removing need to navigate to sub-menus for primary actions

## Test plan
- [x] Build application successfully
- [x] Verify PRs with checks can be clicked directly to open
- [x] Verify checks and jobs can be clicked directly to open
- [x] Confirm sub-menus still work for additional options

🤖 Generated with [Claude Code](https://claude.ai/code)