### PR TITLE
Add duplicate and reorder functionality for search queries

### DIFF
--- a/Sources/MenuBarApp/AppSettings.swift
+++ b/Sources/MenuBarApp/AppSettings.swift
@@ -309,6 +309,44 @@ class AppSettings: ObservableObject {
         saveQueries()
     }
     
+    func duplicateQuery(at index: Int) {
+        guard index >= 0 && index < queries.count else { return }
+        let originalQuery = queries[index]
+        let duplicatedQuery = QueryConfiguration(
+            title: "\(originalQuery.title) (Copy)",
+            query: originalQuery.query,
+            componentOrder: originalQuery.componentOrder,
+            showOrgName: originalQuery.showOrgName,
+            showProjectName: originalQuery.showProjectName,
+            showPRNumber: originalQuery.showPRNumber,
+            showAuthorName: originalQuery.showAuthorName,
+            includeInFailingChecksCount: originalQuery.includeInFailingChecksCount,
+            includeInPendingReviewsCount: originalQuery.includeInPendingReviewsCount
+        )
+        queries.insert(duplicatedQuery, at: index + 1)
+        saveQueries()
+    }
+    
+    func moveQuery(from sourceIndex: Int, to destinationIndex: Int) {
+        guard sourceIndex >= 0 && sourceIndex < queries.count else { return }
+        guard destinationIndex >= 0 && destinationIndex < queries.count else { return }
+        guard sourceIndex != destinationIndex else { return }
+        
+        let query = queries.remove(at: sourceIndex)
+        queries.insert(query, at: destinationIndex)
+        saveQueries()
+    }
+    
+    func moveQueryUp(at index: Int) {
+        guard index > 0 && index < queries.count else { return }
+        moveQuery(from: index, to: index - 1)
+    }
+    
+    func moveQueryDown(at index: Int) {
+        guard index >= 0 && index < queries.count - 1 else { return }
+        moveQuery(from: index, to: index + 1)
+    }
+    
     func loadRefreshInterval() {
         let stored = UserDefaults.standard.double(forKey: refreshIntervalKey)
         if stored > 0 {

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -368,8 +368,13 @@ struct QueriesSettingsView: View {
                     ForEach(Array(appSettings.queries.enumerated()), id: \.element.id) { index, query in
                         QueryRowView(
                             query: query,
+                            index: index,
+                            totalQueries: appSettings.queries.count,
                             onEdit: { editingQuery = query },
-                            onDelete: { appSettings.removeQuery(at: index) }
+                            onDelete: { appSettings.removeQuery(at: index) },
+                            onDuplicate: { appSettings.duplicateQuery(at: index) },
+                            onMoveUp: { appSettings.moveQueryUp(at: index) },
+                            onMoveDown: { appSettings.moveQueryDown(at: index) }
                         )
                     }
                     
@@ -402,8 +407,13 @@ struct QueriesSettingsView: View {
 
 struct QueryRowView: View {
     let query: QueryConfiguration
+    let index: Int
+    let totalQueries: Int
     let onEdit: () -> Void
     let onDelete: () -> Void
+    let onDuplicate: () -> Void
+    let onMoveUp: () -> Void
+    let onMoveDown: () -> Void
     
     var body: some View {
         HStack {
@@ -419,7 +429,33 @@ struct QueryRowView: View {
             
             Spacer()
             
-            HStack(spacing: 8) {
+            HStack(spacing: 12) {
+                HStack(spacing: 4) {
+                    Button(action: onMoveUp) {
+                        Image(systemName: "chevron.up")
+                            .font(.system(size: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(index == 0)
+                    .opacity(index == 0 ? 0.3 : 1.0)
+                    
+                    Button(action: onMoveDown) {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(index == totalQueries - 1)
+                    .opacity(index == totalQueries - 1 ? 0.3 : 1.0)
+                }
+                
+                Button(action: onDuplicate) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.blue)
+                .help("Duplicate query")
+                
                 Button("Edit") { onEdit() }
                     .buttonStyle(.plain)
                     .foregroundColor(.blue)


### PR DESCRIPTION
## Summary
- Add duplicate button to create copies of existing queries with " (Copy)" suffix
- Add up/down arrow buttons to reorder queries in the settings list
- Query order is persisted and reflected in the menu bar dropdown
- Buttons are properly disabled when at list boundaries

## Test plan
- [x] Build succeeds without errors
- [x] Duplicate button creates a copy of the query with proper naming
- [x] Up/down arrows properly reorder queries in the list
- [x] Buttons are disabled appropriately at list boundaries
- [x] Query order persists after app restart
- [x] Menu bar dropdown reflects the new query ordering

🤖 Generated with [Claude Code](https://claude.ai/code)