### PR TITLE
feat: add PR review status with eyes emoji and menubar count

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -106,6 +106,11 @@ struct PullRequestMenuItem: View {
     let queryConfig: QueryConfiguration
     
     private var statusSymbol: String {
+        // Check if PR needs review first
+        if pullRequest.needsReview {
+            return "👀"
+        }
+        
         switch pullRequest.checkStatus {
         case .success:
             return "✅"

--- a/Sources/MenuBarApp/GitHubAPIService.swift
+++ b/Sources/MenuBarApp/GitHubAPIService.swift
@@ -52,9 +52,11 @@ struct GitHubPullRequest: Codable, Identifiable {
     var mergeable: Bool?
     var mergeableState: String?
     var checkRuns: [GitHubCheckRun] = []
+    var requestedReviewers: [GitHubUser]?
+    var assignees: [GitHubUser]?
     
     enum CodingKeys: String, CodingKey {
-        case id, number, title, state, draft, user, mergeable
+        case id, number, title, state, draft, user, mergeable, assignees
         case htmlUrl = "html_url"
         case createdAt = "created_at"
         case updatedAt = "updated_at"
@@ -62,6 +64,7 @@ struct GitHubPullRequest: Codable, Identifiable {
         case repositoryUrl = "repository_url"
         case headSha = "head_sha"
         case mergeableState = "mergeable_state"
+        case requestedReviewers = "requested_reviewers"
     }
     
     var repositoryName: String? {
@@ -149,6 +152,18 @@ struct GitHubPullRequest: Codable, Identifiable {
             return .success
         }
         return .unknown
+    }
+    
+    var needsReview: Bool {
+        // A PR needs review if it has requested reviewers and is assigned to someone
+        // This indicates someone is assigned to review it but hasn't reviewed yet
+        if let requestedReviewers = requestedReviewers,
+           !requestedReviewers.isEmpty,
+           let assignees = assignees,
+           !assignees.isEmpty {
+            return true
+        }
+        return false
     }
 }
 
@@ -370,14 +385,17 @@ struct GitHubPullRequestDetails: Codable {
     let head: PRHead
     let mergeable: Bool?
     let mergeableState: String?
+    let requestedReviewers: [GitHubUser]?
+    let assignees: [GitHubUser]?
     
     struct PRHead: Codable {
         let sha: String
     }
     
     enum CodingKeys: String, CodingKey {
-        case head, mergeable
+        case head, mergeable, assignees
         case mergeableState = "mergeable_state"
+        case requestedReviewers = "requested_reviewers"
     }
 }
 

--- a/Sources/MenuBarApp/PullRequestViewModel.swift
+++ b/Sources/MenuBarApp/PullRequestViewModel.swift
@@ -37,9 +37,8 @@ class PullRequestViewModel: ObservableObject {
         
         for queryResult in queryResults {
             for pr in queryResult.pullRequests {
-                // Count PRs where user's review is requested (only if query allows it)
-                if queryResult.query.query.contains("review-requested:@me") && 
-                   queryResult.query.includeInPendingReviewsCount {
+                // Count PRs that need review (only if query allows it)
+                if pr.needsReview && queryResult.query.includeInPendingReviewsCount {
                     count += 1
                 }
                 // Count PRs authored by user with failing checks or branch conflicts (only if query allows it)
@@ -162,6 +161,8 @@ class PullRequestViewModel: ObservableObject {
                         if let prDetails = prDetails {
                             results[resultIndex].pullRequests[prIndex].mergeable = prDetails.mergeable
                             results[resultIndex].pullRequests[prIndex].mergeableState = prDetails.mergeableState
+                            results[resultIndex].pullRequests[prIndex].requestedReviewers = prDetails.requestedReviewers
+                            results[resultIndex].pullRequests[prIndex].assignees = prDetails.assignees
                         }
                     }
                 }

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -518,7 +518,7 @@ struct QueryEditSheet: View {
                 
                 VStack(alignment: .leading, spacing: 8) {
                     Toggle("Include in failing PR checks count", isOn: $includeInFailingChecksCount)
-                    Toggle("Include in PR count", isOn: $includeInPendingReviewsCount)
+                    Toggle("Include PRs pending review in count", isOn: $includeInPendingReviewsCount)
                 }
                 
                 Text("Controls whether PRs from this query contribute to the menu bar notification count")


### PR DESCRIPTION
## Summary
- Add support for displaying PR review status with 👀 emoji when PRs need review
- Add menubar count support for pending reviews with configurable setting
- Improve UX by showing visual indicators when PRs have requested reviewers and assignees

## Changes
- Added `requestedReviewers` and `assignees` fields to `GitHubPullRequest` model
- Added `needsReview` computed property to detect PRs awaiting review (has both requested reviewers and assignees)
- Updated status symbol logic to show 👀 emoji for PRs that need review
- Enhanced menubar count to include pending reviews when query setting is enabled
- Improved settings toggle text for clarity: "Include PRs pending review in count"
- Leveraged existing PR details API call to fetch review data (no additional API overhead)

## Test plan
- [ ] Verify PRs with requested reviewers and assignees show 👀 emoji
- [ ] Check menubar count includes pending reviews when setting is enabled
- [ ] Confirm settings toggle works correctly
- [ ] Test with different query configurations

🤖 Generated with [Claude Code](https://claude.ai/code)