### PR TITLE
feat: add support for third-party CI providers

### DIFF
--- a/Sources/MenuBarApp/GitHubAPIService.swift
+++ b/Sources/MenuBarApp/GitHubAPIService.swift
@@ -52,6 +52,7 @@ struct GitHubPullRequest: Codable, Identifiable {
     var mergeable: Bool?
     var mergeableState: String?
     var checkRuns: [GitHubCheckRun] = []
+    var commitStatuses: [GitHubCommitStatus] = []
     
     enum CodingKeys: String, CodingKey {
         case id, number, title, state, draft, user, mergeable
@@ -120,15 +121,18 @@ struct GitHubPullRequest: Codable, Identifiable {
     }
     
     var hasFailingChecks: Bool {
-        checkRuns.contains { $0.isFailed }
+        checkRuns.contains { $0.isFailed } || commitStatuses.contains { $0.isFailure }
     }
     
     var hasInProgressChecks: Bool {
-        checkRuns.contains { $0.isInProgress }
+        checkRuns.contains { $0.isInProgress } || commitStatuses.contains { $0.isPending }
     }
     
     var allChecksSuccessful: Bool {
-        !checkRuns.isEmpty && checkRuns.allSatisfy { $0.isSuccessful }
+        let hasChecks = !checkRuns.isEmpty || !commitStatuses.isEmpty
+        let checkRunsSuccess = checkRuns.isEmpty || checkRuns.allSatisfy { $0.isSuccessful }
+        let statusesSuccess = commitStatuses.isEmpty || commitStatuses.allSatisfy { $0.isSuccess }
+        return hasChecks && checkRunsSuccess && statusesSuccess
     }
     
     var checkStatus: CheckStatus {
@@ -136,7 +140,7 @@ struct GitHubPullRequest: Codable, Identifiable {
         if hasBranchConflicts {
             return .failed
         }
-        if checkRuns.isEmpty {
+        if checkRuns.isEmpty && commitStatuses.isEmpty {
             return .unknown
         }
         if hasFailingChecks {
@@ -353,6 +357,66 @@ struct GitHubCheckRunsResponse: Codable {
     
     enum CodingKeys: String, CodingKey {
         case checkRuns = "check_runs"
+    }
+}
+
+struct GitHubCommitStatus: Codable, Identifiable {
+    let id: Int
+    let state: String
+    let description: String?
+    let targetUrl: String?
+    let context: String
+    let createdAt: Date
+    let updatedAt: Date
+    let creator: GitHubUser?
+    
+    enum CodingKeys: String, CodingKey {
+        case id, state, description, context, creator
+        case targetUrl = "target_url"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+    
+    var isSuccess: Bool {
+        state == "success"
+    }
+    
+    var isFailure: Bool {
+        state == "failure" || state == "error"
+    }
+    
+    var isPending: Bool {
+        state == "pending"
+    }
+    
+    var displayName: String {
+        // Extract a cleaner name from context (e.g., "ci/circleci: build" -> "CircleCI: build")
+        if context.contains("circleci") {
+            return context.replacingOccurrences(of: "ci/circleci:", with: "CircleCI:")
+                          .replacingOccurrences(of: "ci/circleci/", with: "CircleCI/")
+        } else if context.contains("travis") {
+            return context.replacingOccurrences(of: "continuous-integration/travis-ci/", with: "Travis CI/")
+        } else if context.contains("jenkins") {
+            return context.replacingOccurrences(of: "continuous-integration/jenkins/", with: "Jenkins/")
+        } else if context.contains("buildkite") {
+            return context.replacingOccurrences(of: "buildkite/", with: "Buildkite/")
+        } else if context.contains("appveyor") {
+            return context.replacingOccurrences(of: "continuous-integration/appveyor/", with: "AppVeyor/")
+        }
+        return context
+    }
+}
+
+struct GitHubCombinedStatus: Codable {
+    let state: String
+    let statuses: [GitHubCommitStatus]
+    let sha: String
+    let totalCount: Int
+    let repository: GitHubRepository
+    
+    enum CodingKeys: String, CodingKey {
+        case state, statuses, sha, repository
+        case totalCount = "total_count"
     }
 }
 
@@ -588,6 +652,39 @@ class GitHubAPIService: ObservableObject {
         } catch {
             #if DEBUG
             print("Check runs JSON decoding error: \(error)")
+            if let responseString = String(data: data, encoding: .utf8) {
+                let truncated = String(responseString.prefix(200))
+                print("Response preview: \(truncated)...")
+            }
+            #endif
+            throw error
+        }
+    }
+    
+    func fetchCommitStatuses(for owner: String, repo: String, sha: String, token: String) async throws -> [GitHubCommitStatus] {
+        guard let url = URL(string: "\(baseURL)/repos/\(owner)/\(repo)/commits/\(sha)/status") else {
+            throw GitHubAPIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        
+        let (data, response) = try await urlSession.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubAPIError.invalidResponse
+        }
+        
+        try handleAPIResponse(httpResponse)
+        
+        do {
+            let combinedStatus = try jsonDecoder.decode(GitHubCombinedStatus.self, from: data)
+            return combinedStatus.statuses
+        } catch {
+            #if DEBUG
+            print("Commit statuses JSON decoding error: \(error)")
             if let responseString = String(data: data, encoding: .utf8) {
                 let truncated = String(responseString.prefix(200))
                 print("Response preview: \(truncated)...")


### PR DESCRIPTION
## Summary
- Implements GitHub Status API support for third-party CI providers (CircleCI, Travis CI, Jenkins, Buildkite, etc.)
- Adds concurrent fetching of both Check Runs and Status APIs for complete CI coverage
- Enhances UI to display all CI results with proper status symbols and clickable links

## Changes Made
- **New Models**: Added `GitHubCommitStatus` and `GitHubCombinedStatus` for Status API integration
- **API Integration**: Implemented `fetchCommitStatuses()` method with proper error handling
- **Data Layer**: Enhanced `GitHubPullRequest` model to store both check runs and commit statuses
- **Status Logic**: Updated check status calculation to consider both CI sources
- **Performance**: Modified `PullRequestViewModel` to fetch both APIs concurrently using `async let`
- **UI Enhancement**: Updated menu to display commit statuses alongside existing check runs
- **User Experience**: Added smart display name formatting for popular CI providers

## Technical Details
- Uses GitHub's `/repos/{owner}/{repo}/commits/{sha}/status` endpoint for Status API
- Maintains backward compatibility with existing Check Runs functionality
- Implements concurrent API fetching to minimize performance impact
- Provides unified status calculation combining both data sources
- Includes proper error handling and debugging support

## Test Plan
- [x] Build succeeds without errors
- [x] Existing GitHub Actions checks continue to work
- [x] New Status API integration fetches third-party CI results
- [x] UI properly displays both types of CI checks
- [x] Status symbols and links work correctly
- [ ] Test with repositories using CircleCI, Travis CI, Jenkins, etc.

This resolves the issue where third-party CI providers weren't showing up in the menu bar app, providing complete visibility into all CI/CD checks for pull requests.

🤖 Generated with [Claude Code](https://claude.ai/code)