### PR TITLE
Show green check for PRs ready to merge

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -106,6 +106,15 @@ struct PullRequestMenuItem: View {
     let queryConfig: QueryConfiguration
     
     private var statusSymbol: String {
+        // Always show green check for PRs ready to merge
+        if pullRequest.isReadyToMerge {
+            return "✅"
+        }
+        
+        #if DEBUG
+        print("PR #\(pullRequest.number) '\(pullRequest.title)': checkStatus=\(pullRequest.checkStatus), statusSymbol will be...")
+        #endif
+        
         switch pullRequest.checkStatus {
         case .success:
             return "✅"

--- a/Sources/MenuBarApp/GitHubAPIService.swift
+++ b/Sources/MenuBarApp/GitHubAPIService.swift
@@ -131,6 +131,19 @@ struct GitHubPullRequest: Codable, Identifiable {
         !checkRuns.isEmpty && checkRuns.allSatisfy { $0.isSuccessful }
     }
     
+    var isReadyToMerge: Bool {
+        // A PR is ready to merge when:
+        // 1. It's not a draft
+        // 2. It's mergeable (no conflicts)
+        // 3. Either has no checks OR all checks have passed
+        let checksOk = checkRuns.isEmpty || allChecksSuccessful
+        let ready = !draft && checksOk && mergeable == true
+        #if DEBUG
+        print("PR #\(number): isReadyToMerge=\(ready), draft=\(draft), checksOk=\(checksOk), checkRuns.count=\(checkRuns.count), mergeable=\(mergeable?.description ?? "nil")")
+        #endif
+        return ready
+    }
+    
     var checkStatus: CheckStatus {
         // Branch conflicts take precedence over check status
         if hasBranchConflicts {


### PR DESCRIPTION
## Summary
- Adds visual indicator when PRs are ready to merge by showing green check (✅)
- PRs show green check when: not a draft, mergeable (no conflicts), and either no checks or all checks passing
- Handles PRs without CI checks that are still ready to merge

## Test plan
- [x] Build succeeds without errors
- [x] PRs with no checks but mergeable status show green check
- [x] PRs with all checks passing show green check
- [x] Draft PRs do not show green check
- [x] PRs with failing checks do not show green check
- [x] PRs with merge conflicts do not show green check

🤖 Generated with [Claude Code](https://claude.ai/code)