### PR TITLE
Add last modified time display option for PRs

### DIFF
--- a/Sources/MenuBarApp/App.swift
+++ b/Sources/MenuBarApp/App.swift
@@ -339,6 +339,9 @@ struct PullRequestMenuItem: View {
                 if !pullRequest.user.login.isEmpty {
                     result.append("@\(pullRequest.user.login)")
                 }
+                
+            case .lastModified:
+                result.append(pullRequest.updatedAt.shortTimeAgoDisplay())
             }
         }
         

--- a/Sources/MenuBarApp/AppSettings.swift
+++ b/Sources/MenuBarApp/AppSettings.swift
@@ -9,6 +9,7 @@ enum PRDisplayComponent: String, CaseIterable, Codable, Identifiable {
     case prNumber = "pr_number"
     case authorName = "author_name"
     case separator = "separator"
+    case lastModified = "last_modified"
     
     var id: String { rawValue }
     
@@ -21,6 +22,7 @@ enum PRDisplayComponent: String, CaseIterable, Codable, Identifiable {
         case .prNumber: return "PR Number"
         case .authorName: return "Author"
         case .separator: return "Separator (–)"
+        case .lastModified: return "Last Modified"
         }
     }
     
@@ -33,6 +35,7 @@ enum PRDisplayComponent: String, CaseIterable, Codable, Identifiable {
         case .prNumber: return "#1234"
         case .authorName: return "@johndoe"
         case .separator: return "–"
+        case .lastModified: return "2 hours ago"
         }
     }
 }

--- a/Sources/MenuBarApp/DateFormatterUtility.swift
+++ b/Sources/MenuBarApp/DateFormatterUtility.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension Date {
+    func timeAgoDisplay() -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: self, relativeTo: Date())
+    }
+    
+    func shortTimeAgoDisplay() -> String {
+        let now = Date()
+        let components = Calendar.current.dateComponents([.year, .month, .weekOfYear, .day, .hour, .minute], from: self, to: now)
+        
+        if let year = components.year, year > 0 {
+            return year == 1 ? "1 year ago" : "\(year) years ago"
+        }
+        
+        if let month = components.month, month > 0 {
+            return month == 1 ? "1 month ago" : "\(month) months ago"
+        }
+        
+        if let week = components.weekOfYear, week > 0 {
+            return week == 1 ? "1 week ago" : "\(week) weeks ago"
+        }
+        
+        if let day = components.day, day > 0 {
+            return day == 1 ? "1 day ago" : "\(day) days ago"
+        }
+        
+        if let hour = components.hour, hour > 0 {
+            return hour == 1 ? "1 hour ago" : "\(hour) hours ago"
+        }
+        
+        if let minute = components.minute, minute > 0 {
+            return minute == 1 ? "1 min ago" : "\(minute) mins ago"
+        }
+        
+        return "Just now"
+    }
+}

--- a/Sources/MenuBarApp/SettingsView.swift
+++ b/Sources/MenuBarApp/SettingsView.swift
@@ -982,7 +982,7 @@ struct DragDropPreviewPRItem: View {
                 }
                 // Separator is handled by joining with " – "
                 
-            case .orgName, .projectName, .prNumber, .authorName:
+            case .orgName, .projectName, .prNumber, .authorName, .lastModified:
                 currentGroup.append(component.exampleText)
             }
         }


### PR DESCRIPTION
## Summary
- Added a new "Last Modified" display component for pull requests
- Shows human-readable relative times (e.g., "2 hours ago", "3 days ago")
- Available as an optional drag-and-drop component in preferences

## Details
This PR adds the ability to display when a pull request was last modified, using the GitHub API's `updatedAt` field which captures any activity on the PR including:
- New commits
- Comments
- CI/CD runs
- Description changes
- Review activity

The time is displayed in a human-readable format using a custom date formatter that shows:
- "Just now" for very recent updates
- "X mins ago" for updates within the hour
- "X hours ago" for updates today
- "X days ago" for updates this week
- "X weeks ago" for updates this month
- And so on...

The component is optional and not included in any default configurations, allowing users to add it only if they find it useful.

## Test plan
- [x] Build the application
- [ ] Add the "Last Modified" component to a query configuration
- [ ] Verify times display correctly for various PRs
- [ ] Test drag-and-drop functionality in settings
- [ ] Confirm component can be removed if not wanted

🤖 Generated with [Claude Code](https://claude.ai/code)