### PR TITLE
fix: resolve check run duplication in menu display

### DIFF
--- a/Sources/MenuBarApp/GitHubGraphQLService.swift
+++ b/Sources/MenuBarApp/GitHubGraphQLService.swift
@@ -464,8 +464,10 @@ class GitHubGraphQLService: ObservableObject {
                             guard let run = run else { continue }
                             
                             let checkRunId = extractNumericId(from: run.id)
+                            // Use hash-based fallback ID if GraphQL ID parsing fails to prevent duplicates
+                            let uniqueId = checkRunId != 0 ? checkRunId : run.id.hashValue
                             let checkRun = GitHubCheckRun(
-                                id: checkRunId,
+                                id: uniqueId,
                                 headSha: prNode.headRefOid,
                                 status: run.status.lowercased(),
                                 conclusion: run.conclusion?.lowercased(),
@@ -480,7 +482,7 @@ class GitHubGraphQLService: ObservableObject {
                                 },
                                 jobs: []
                             )
-                            checkRunsById[checkRunId] = checkRun
+                            checkRunsById[uniqueId] = checkRun
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Fixed check run duplication bug where multiple check runs displayed the same content
- Issue was caused by SwiftUI ForEach identity confusion when multiple check runs had ID 0
- Applied same solution as previous PR title duplication fix (commit 56b7f30)

## Root Cause
The `extractNumericId()` function returns 0 as fallback when GraphQL ID parsing fails. When multiple check runs couldn't be parsed, they all got `id: 0`, causing SwiftUI's ForEach to display duplicates.

## Changes
- Use hash-based fallback ID when GraphQL ID parsing fails for check runs
- Ensures all check runs have unique IDs for proper SwiftUI display  
- Update deduplication logic to use the unique ID consistently

## Test Plan
- [x] Build compiles successfully
- [x] Follows same pattern as previous PR title fix
- [ ] Manual testing with PRs that have multiple check runs

🤖 Generated with [Claude Code](https://claude.ai/code)